### PR TITLE
Fix skill icons in charamake race menu

### DIFF
--- a/src/api/gui/menu/chara_make/UiRaceInfo.lua
+++ b/src/api/gui/menu/chara_make/UiRaceInfo.lua
@@ -126,7 +126,7 @@ function UiRaceInfo:draw()
          local skill_text = ("%s: %s"):format(skill_name, proficiency)
 
          self.t.base.skill_icons:draw_region(
-            Ui.skill_icon(skill_entry.skill),
+            Ui.skill_icon(skill_id),
             j * 150 + self.x + 200 + 13,
             self.y + ty + 7,
             nil,
@@ -197,11 +197,8 @@ function UiRaceInfo:draw()
          local skill_name = I18N.get("ability." .. proto._id .. ".name")
          skill_name = right_pad(skill_name, pad_size)
 
-         local related_skill = proto.related_skill
-         related_skill = I18N.get("ability." .. related_skill .. ".name")
-
          self.t.base.skill_icons:draw_region(
-            1,
+            Ui.skill_icon(proto.related_skill),
             self.x + 200 + 13,
             self.y + 260 + 34 + rows*14 + 6,
             nil,


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

### Description

Fix skill icons in `charamake/UiRaceInfo` menu. For basic stats, their icons should be displayed. For normal skills, their `related_skill`'s icons should be displayed.

Screenshot:

![image](https://user-images.githubusercontent.com/36858341/89499476-0d697680-d7fb-11ea-963e-f4810e596af0.png)
