### PR TITLE
Fix error in charamake feats selection menu

### DIFF
--- a/src/api/gui/menu/FeatsMenu.lua
+++ b/src/api/gui/menu/FeatsMenu.lua
@@ -253,7 +253,11 @@ function FeatsMenu:update()
             self.chara.feats_acquirable = self.chara.feats_acquirable - 1
             Gui.play_sound("base.ding3")
             self.chara:increment_trait(item.trait._id, true)
-            self.chara:refresh()
+            if not self.chara_make then
+               -- In character making, `self.chara` has not been built yet by `IChara:built`.
+               -- Because most callbacks expect the given character to be built, you cannot call `refresh` during character making.
+               self.chara:refresh()
+            end
             self.data = FeatsMenu.generate_list(self.chara)
             self.pages:set_data(self.data)
 


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

How to reproduce:

1. Generate a new character.
2. Select race, gender and class.
3. Select feat in the below menu.

![image](https://user-images.githubusercontent.com/36858341/89502326-c762e180-d7ff-11ea-979e-be7ebcc30144.png)

Error log:

```
[error][api.gui.IUiLayer] Error on query:
	./mod/elona_sys/api/Skill.lua:344: attempt to perform arithmetic on a nil value
stack traceback:
	./api/gui/IUiLayer.lua:21: in function '__sub'
	./mod/elona_sys/api/Skill.lua:344: in function 'refresh_speed'
	./mod/elona_sys/api/Skill.lua:547: in function 'cb'
	./api/EventTree.lua:138: in function 'trigger'
	./api/EventHolder.lua:186: in function 'cb'
	./api/EventTree.lua:138: in function 'trigger'
	./api/EventHolder.lua:186: in function 'emit'
	./api/chara/IChara.lua:250: in function 'refresh_weight'
	./api/chara/IChara.lua:131: in function 'refresh'
	./api/gui/menu/FeatsMenu.lua:256: in function 'update'
	./api/gui/menu/chara_make/SelectFeatsMenu.lua:64: in function 'update'
	./api/gui/menu/chara_make/CharaMakeWrapper.lua:204: in function <./api/gui/menu/chara_make/CharaMakeWrapper.lua:199>
	[C]: in function 'xpcall'
```


### Description

> ./mod/elona_sys/api/Skill.lua:344: attempt to perform arithmetic on a nil value

This error happens here:

```lua
-- mod/elona_sys/api/Skill.lua: Skill.refresh_speed()
   chara.current_speed = math.floor(chara:skill_level("elona.stat_speed") + math.clamp(100 - chara:calc("speed_correction"), 0, 100) / 100)
```

The exact cause is that `chara:calc("speed_correction")` returns `nil`. Because the character has not been built yet by calling`IChara:build()` during character making, `speed_correction`, one of the fields of `base.chara`'s `fallbacks`, has not been added to the character instance by `build()`.
I fix it by not calling `IChara:refresh()` if `chara_make` is true, but it seems to be work-around.