### PR TITLE
Automatically wrap text in LOVE's Text object inside Draw.text

### DIFF
--- a/editor/emacs/open-nefia.el
+++ b/editor/emacs/open-nefia.el
@@ -850,14 +850,14 @@ removed.  Return the new string.  If STRING is nil, return nil."
   (let* ((path (file-relative-name
                 (buffer-file-name)
                 (string-join (list (projectile-project-root) "src"))))
-         (script (if (eq system-type 'windows-nt) "OpenNefia_REPL.bat" "./OpenNefia_REPL"))
+         (script (if (eq system-type 'windows-nt) "./OpenNefia_REPL.bat" "./OpenNefia_REPL"))
          (cmd (format "%s batch %s" script path))
          (default-directory (projectile-project-root)))
     (compile cmd)))
 
 (defun open-nefia-start-game ()
   (interactive)
-  (let* ((cmd (if (eq system-type 'windows-nt) "OpenNefia.bat" "./OpenNefia"))
+  (let* ((cmd (if (eq system-type 'windows-nt) "./OpenNefia.bat" "./OpenNefia"))
          (default-directory (projectile-project-root)))
     (setq compilation-search-path (list nil "src"))
     (compile cmd)))

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -94,6 +94,8 @@ function Draw.clear(r, g, b, a)
    end
 end
 
+local text_cache = setmetatable({}, { __mode = "kv" })
+
 --- Draws text.
 ---
 --- @tparam string str
@@ -111,7 +113,9 @@ function Draw.text(str, x, y, color, size)
    if str.typeOf and str:typeOf("Text") then
       love.graphics.draw(str, x, y)
    else
-      love.graphics.print(str, x, y)
+      local text = text_cache[str] or Draw.make_text(str)
+      text_cache[str] = text
+      love.graphics.draw(text, x, y)
    end
 end
 

--- a/src/api/gui/Pcc.lua
+++ b/src/api/gui/Pcc.lua
@@ -107,6 +107,8 @@ function Pcc:draw(x, y, scale_x, scale_y)
    scale_y = scale_y or 1.0
 
    if self.full_size then
+      width = 32
+      height = 48
       offset_x = 8
       offset_y = -4
    else

--- a/src/internal/data/fallbacks.lua
+++ b/src/internal/data/fallbacks.lua
@@ -15,5 +15,7 @@ data:add {
    _type = "base.chara",
    _id = "player",
 
-   level = 1
+   level = 1,
+   rarity = 0,
+   coefficient = 0
 }


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [x] Enhancement
- [ ] New feature

### Description

Automatically wraps strings in a `Text` object in `Draw.text()`, and caches the result in a weak table.

This greatly improves performance on my older Windows hardware.