### PR TITLE
Mock working directory at the filesystem layer

### DIFF
--- a/src/api/Fs.lua
+++ b/src/api/Fs.lua
@@ -9,12 +9,17 @@ Fs.basename = fs.basename
 Fs.filename_part = fs.filename_part
 Fs.extension_part = fs.extension_part
 Fs.convert_to_require_path = paths.convert_to_require_path
+Fs.get_working_directory = fs.get_working_directory
 
 function Fs.open(filepath, mode)
    assert(mode, "mode is required")
 
    -- love.File:open() does not support "rb"
    mode = mode:gsub("b$", "")
+
+   if not fs.is_absolute(filepath) then
+      filepath = fs.join(Fs.get_working_directory(), filepath)
+   end
 
    local file = love.filesystem.newFile(filepath)
    local ok, err = file:open(mode)

--- a/src/api/IEventEmitter.lua
+++ b/src/api/IEventEmitter.lua
@@ -25,12 +25,6 @@ function IEventEmitter:on_reload_prototype()
    end
 end
 
-Event.register("base.on_hotload_object", "reload events for object", function(obj)
-                  if class.is_an(IEventEmitter, obj) then
-                     IEventEmitter.on_reload_prototype(obj)
-                  end
-end)
-
 local cache = {}
 
 local function register_global_handler_if_needed(self, event_id, global_events)

--- a/src/api/chara/ICharaEffects.lua
+++ b/src/api/chara/ICharaEffects.lua
@@ -76,42 +76,6 @@ function ICharaEffects:remove_all_effects()
    self.effects = {}
 end
 
-local function calc_power_after_resistance(chara, effect, element, power)
-   local resistance = chara:resist_level(element._id)
-   local level = math.floor(resistance / 50)
-   power = (Rand.rnd(math.floor(power / 2) + 1) + math.floor(power / 2)) * 100 / (50 + level * 50)
-
-   if level >= 3 and power < 40 then
-      return 0
-   end
-
-   return power
-end
-
-local function calc_effect_power_resist(chara, params, power)
-   local effect = params.effect
-
-   if effect.related_element ~= nil then
-      local element = data["base.element"][effect.related_element]
-      if element ~= nil then
-         power = calc_power_after_resistance(chara, effect, element, power)
-      end
-   end
-
-   return power
-end
-Event.register("elona_sys.calc_effect_power",
-               "Effect power from elemental resistance",
-               calc_effect_power_resist)
-
-local function calc_effect_power_reduction(chara, params, power)
-   local reduction = params.effect.power_reduction_factor or 1
-   return math.floor(power / reduction)
-end
-Event.register("elona_sys.calc_effect_power",
-               "Effect power from power reduction",
-               calc_effect_power_reduction)
-
 --- @hsp dmgCon
 function ICharaEffects:apply_effect(id, power, params)
    power = power or 10
@@ -164,12 +128,6 @@ function ICharaEffects:apply_effect(id, power, params)
 
    return true
 end
-
-Event.register("elona_sys.on_apply_effect", "Stop activity", function(chara, params)
-                  if params.effect.stops_activity then
-                     chara:remove_activity()
-                  end
-end)
 
 function ICharaEffects:heal_effect(id, power, params)
    params = params or {}

--- a/src/game/startup.lua
+++ b/src/game/startup.lua
@@ -39,7 +39,7 @@ local function copy_files(src, dest)
    end
 
    for _, name in fs.iter_directory_items(src) do
-      local src_file = fs.join(src, name)
+      local src_file = fs.join(fs.get_working_directory(), src, name)
       local dest_file = fs.join(fs.get_working_directory(), dest, name)
 
       -- HACK: Because of LÖVE's restriction that you can only write

--- a/src/internal/debug_server.lua
+++ b/src/internal/debug_server.lua
@@ -45,7 +45,7 @@ function commands.run(args)
       -- potentially leave the debug server in an invalid state. To
       -- protect against this, run the code itself in a new coroutine
       -- so if the code yields it will not affect any state.
-      local coro = coroutine.create(function() xpcall(fn, function(e) return e .. "\n" .. debug.traceback(2) end) end)
+      local coro = coroutine.create(function() return xpcall(fn, function(e) return e .. "\n" .. debug.traceback(2) end) end)
       repeat
          continue, success, result = coroutine.resume(coro, dt, nil)
          dt = coroutine.yield()

--- a/src/internal/events/on_hotload.lua
+++ b/src/internal/events/on_hotload.lua
@@ -24,6 +24,12 @@ end
 Event.register("base.on_hotload_begin", "Clean up events missing in chunk on hotload", on_hotload_begin, {priority = 1})
 Event.register("base.on_hotload_end", "Clean up events missing in chunk on hotload", on_hotload_end, {priority = 9999999999})
 
+Event.register("base.on_hotload_object", "reload events for object", function(obj)
+                  if class.is_an(IEventEmitter, obj) then
+                     IEventEmitter.on_reload_prototype(obj)
+                  end
+end)
+
 Event.register("base.on_map_loaded", "init all event callbacks",
                function(map)
                   local objs = map:iter():to_list()

--- a/src/mod/elona_sys/events.lua
+++ b/src/mod/elona_sys/events.lua
@@ -782,3 +782,45 @@ local function check_escort_quest_targets(map)
    end
 end
 Event.register("elona_sys.on_quest_check", "Check escort quest targets", check_escort_quest_targets)
+
+local function calc_power_after_resistance(chara, effect, element, power)
+   local resistance = chara:resist_level(element._id)
+   local level = math.floor(resistance / 50)
+   power = (Rand.rnd(math.floor(power / 2) + 1) + math.floor(power / 2)) * 100 / (50 + level * 50)
+
+   if level >= 3 and power < 40 then
+      return 0
+   end
+
+   return power
+end
+
+local function calc_effect_power_resist(chara, params, power)
+   local effect = params.effect
+
+   if effect.related_element ~= nil then
+      local element = data["base.element"][effect.related_element]
+      if element ~= nil then
+         power = calc_power_after_resistance(chara, effect, element, power)
+      end
+   end
+
+   return power
+end
+Event.register("elona_sys.calc_effect_power",
+               "Effect power from elemental resistance",
+               calc_effect_power_resist)
+
+local function calc_effect_power_reduction(chara, params, power)
+   local reduction = params.effect.power_reduction_factor or 1
+   return math.floor(power / reduction)
+end
+Event.register("elona_sys.calc_effect_power",
+               "Effect power from power reduction",
+               calc_effect_power_reduction)
+
+Event.register("elona_sys.on_apply_effect", "Stop activity", function(chara, params)
+                  if params.effect.stops_activity then
+                     chara:remove_activity()
+                  end
+end)

--- a/src/util/lovemock.lua
+++ b/src/util/lovemock.lua
@@ -3,7 +3,7 @@ local love = require("thirdparty.automagic")()
 
 local function check_path(path)
    if type(path) == "string" then
-      assert(fs.is_file(path), "File does not exist: " .. path)
+      -- assert(fs.is_file(path), "File does not exist: " .. path)
    end
 end
 
@@ -116,7 +116,12 @@ end
 love.timer.sleep = function() end
 love.system.getOS = function() return "lovemock" end
 love.filesystem.setRequirePath = function() end
-love.filesystem.load = loadfile
+love.filesystem.load = function(path)
+   if fs.is_absolute(path) then
+      return loadfile(path)
+   end
+   return loadfile(fs.join(fs.get_working_directory(), path))
+end
 love.filesystem.newFile = function(filepath)
    return {
       open = function(self, mode)


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [x] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

### Description
Was testing out using OpenNefia as a library. This change lets you mock the working directory for filesystem operations so you can put the repo in a subdirectory and load it from some parent code, like a Discord bot.

It's just an optional feature for internal purposes.