### PR TITLE
Implement the house board for Your Home

### DIFF
--- a/editor/emacs/open-nefia.el
+++ b/editor/emacs/open-nefia.el
@@ -896,14 +896,14 @@ removed.  Return the new string.  If STRING is nil, return nil."
 (defun open-nefia-run-tests-this-file (&optional arg)
   (interactive "P")
   (open-nefia--run-tests
-   (format "%s:%s" (file-name-base (buffer-file-name)) ".*") arg))
+   (format "%s:%s" (format "/%s.lua$" (file-name-base (buffer-file-name))) ".*") arg))
 
 (defun open-nefia-run-test-at-point (&optional arg)
   (interactive "P")
   (let ((func-at-point (which-function)))
     (if func-at-point
         (open-nefia--run-tests
-         (format "%s:%s" (file-name-base (buffer-file-name)) (format "^%s$" func-at-point) arg))
+         (format "%s:%s" (format "/%s.lua$" (file-name-base (buffer-file-name))) (format "^%s$" func-at-point) arg))
       (message "No function at point."))))
 
 (defun open-nefia-run-previous-tests (&optional arg)

--- a/src/api/Input.lua
+++ b/src/api/Input.lua
@@ -140,13 +140,19 @@ end
 --- Queries the player for a position.
 ---
 --- @tparam[opt] IChara chara Defaults to the player.
+--- @tparam[opt] integer init_x
+--- @tparam[opt] integer init_y
 --- @treturn[opt] int x
 --- @treturn[opt] int y
 --- @treturn[opt] boolean can_see
 --- @treturn[opt] string error
-function Input.query_position(chara)
-   chara = chara or Chara.player()
-   local result, canceled = PositionPrompt:new(chara.x, chara.y, nil, nil, chara):query()
+function Input.query_position(chara, init_x, init_y)
+   chara = chara or assert(Chara.player())
+   if init_x == nil then
+      init_x = chara.x
+      init_y = chara.y
+   end
+   local result, canceled = PositionPrompt:new(init_x, init_y, nil, nil, chara):query()
    if canceled then
       return nil, canceled
    end

--- a/src/api/Map.lua
+++ b/src/api/Map.lua
@@ -67,7 +67,12 @@ function Map.save(map)
       Log.debug("Autogenerating new area for map '%d'", map.uid)
       local area = InstancedArea:new()
       area:add_floor(map)
-      Area.register(area)
+      local parent = Area.for_map(map)
+      if parent == nil then
+         Log.debug("Generating new root area since this map isn't part of an area.")
+         parent = "root"
+      end
+      Area.register(area, { parent = parent })
    end
 
    return ok, err
@@ -498,8 +503,6 @@ function Map.try_place_chara(chara, x, y, map)
       assert(can_place_chara_at(real_x, real_y, map))
 
       Log.debug("Place %s %d,%d --> %d,%d", chara._id, x, y, real_x, real_y)
-      chara.initial_x = real_x
-      chara.initial_y = real_y
 
       local result = map:take_object(chara, real_x, real_y)
       if result then
@@ -571,7 +574,12 @@ function Map.travel_to(map, params)
       area.parent_y = player.y
       area.parent_floor = floor
       area:add_floor(map)
-      Area.register(area, { parent = Area.for_map(current) })
+      local parent = Area.for_map(current)
+      if parent == nil then
+         Log.debug("Generating new root area since this map isn't part of an area.")
+         parent = "root"
+      end
+      Area.register(area, { parent = parent })
    end
 
    -- >>>>>>>> shade2/map.hsp:1863 	randomize ..

--- a/src/api/MapObject.lua
+++ b/src/api/MapObject.lua
@@ -99,8 +99,16 @@ function MapObject.clone_base(obj, owned)
    return new_object
 end
 
-function MapObject.is_map_object(t)
-   return class.is_an(IMapObject, t) or false
+function MapObject.is_map_object(t, _type)
+   if not class.is_an(IMapObject, t) then
+      return false
+   end
+
+   if _type == nil then
+      return true
+   end
+
+   return _type == t._type
 end
 
 -- NOTE: We could have an interface for classes that need special cloning logic.

--- a/src/api/ObjectContainer.lua
+++ b/src/api/ObjectContainer.lua
@@ -1,13 +1,19 @@
 --- @module ObjectContainer
 
 local ILocation = require("api.ILocation")
+local IOwned = require("api.IOwned")
 local pool = require("internal.pool")
 
 local ObjectContainer = class.class("ObjectContainer", ILocation)
 
 --- @tparam string ty
-function ObjectContainer:init(ty)
-   self.pool = pool:new(ty, 1, 1)
+function ObjectContainer:init(ty, owner)
+   if owner then
+      assert(class.is_an(IOwned, owner))
+      self._parent = owner
+   end
+
+   self.pool = pool:new(ty, 1, 1, self)
 end
 
 --

--- a/src/api/StayingCharas.lua
+++ b/src/api/StayingCharas.lua
@@ -1,0 +1,117 @@
+local MapObject = require("api.MapObject")
+local ILocation = require("api.ILocation")
+local Map = require("api.Map")
+local IOwned = require("api.IOwned")
+local ObjectContainer = require("api.ObjectContainer")
+local Chara = require("api.Chara")
+local InstancedMap = require("api.InstancedMap")
+local Log = require("api.Log")
+local save = require("internal.global.save")
+local I18N = require("api.I18N")
+
+local StayingCharas = class.class("StayingCharas", ILocation)
+
+StayingCharas:delegate("container", ILocation)
+
+function StayingCharas:init(owner)
+   if owner then
+      assert(class.is_an(IOwned, owner))
+      self._parent = owner
+   end
+
+   self.container = ObjectContainer:new("base.chara", self)
+   self.map_uid_to_chara_uids = {}
+   self.chara_uid_to_map_uid = {}
+end
+
+function StayingCharas.register_global(chara, map)
+   save.base.staying_charas:register(chara, map)
+end
+
+function StayingCharas.unregister_global(chara)
+   save.base.staying_charas:unregister(chara)
+end
+
+function StayingCharas.iter_global()
+   save.base.staying_charas:iter()
+end
+
+function StayingCharas:register(chara, map)
+   assert(MapObject.is_map_object(chara, "base.chara"))
+   class.assert_is_an(InstancedMap, map)
+   local old_map = self:get_staying_map_for(chara)
+   if old_map then
+      self.map_uid_to_chara_uids[old_map.map_uid][chara.uid] = nil
+      self.chara_uid_to_map_uid[chara.uid] = nil
+   end
+
+   self.map_uid_to_chara_uids[map.uid] = self.map_uid_to_chara_uids[map.uid] or {}
+   self.map_uid_to_chara_uids[map.uid][chara.uid] = true
+   self.chara_uid_to_map_uid[chara.uid] = {
+      map_uid = map.uid,
+      map_name = map.name or I18N.get("ui.adventurers.unknown")
+   }
+end
+
+function StayingCharas:unregister(chara)
+   assert(MapObject.is_map_object(chara, "base.chara"))
+   local old_map = self:get_staying_map_for(chara)
+   if not old_map then
+      return
+   end
+
+   self.map_uid_to_chara_uids[old_map.map_uid][chara.uid] = nil
+   self.chara_uid_to_map_uid[chara.uid] = nil
+
+   return nil
+end
+
+function StayingCharas:get_staying_map_for(chara)
+   assert(MapObject.is_map_object(chara, "base.chara"))
+   local map = self.chara_uid_to_map_uid[chara.uid]
+   if not map then
+      return nil
+   end
+
+   return { map_uid = map.map_uid, map_name = map.map_name }
+end
+
+function StayingCharas:do_transfer(map)
+   local is_outside_staying_map = function(chara)
+      local staying_map = self:get_staying_map_for(chara)
+      return chara.state == "Alive"
+         and not chara:is_player()
+         and staying_map
+         and staying_map.map_uid ~= map.uid
+   end
+
+   local function take(chara)
+      assert(self:take_object(chara))
+      assert(chara:get_location() == self)
+      chara.state = "Staying"
+   end
+
+   Chara.iter_all(map):filter(is_outside_staying_map):each(take)
+
+   local is_inside_staying_map = function(chara)
+      local staying_map = self:get_staying_map_for(chara)
+      return staying_map
+         and staying_map.map_uid == map.uid
+   end
+
+   local function place(chara)
+      -- TODO building original position
+      local x = nil
+      local y = nil
+      if Map.try_place_chara(chara, x, y, map) then
+         chara.state = "Alive"
+      else
+         assert(chara:get_location() == self)
+         Log.warn("Could not restore staying character %d (%s)", chara.uid, chara.name)
+      end
+   end
+
+   self:iter():filter(is_inside_staying_map):each(place)
+end
+
+return StayingCharas

--- a/src/api/chara/IChara.lua
+++ b/src/api/chara/IChara.lua
@@ -10,6 +10,7 @@ local Map = require("api.Map")
 local I18N = require("api.I18N")
 local Const = require("api.Const")
 local World = require("api.World")
+local StayingCharas = require("api.StayingCharas")
 local ICharaEffects = require("api.chara.ICharaEffects")
 local ICharaEquip = require("api.chara.ICharaEquip")
 local ICharaInventory = require("api.chara.ICharaInventory")
@@ -528,6 +529,7 @@ function IChara:kill(source)
       self.state = "Dead"
    end
    self.is_solid = nil
+   StayingCharas.unregister_global(self)
 
    self:refresh_cell_on_map()
 
@@ -548,6 +550,7 @@ function IChara:vanquish()
 
    self.state = "Dead"
    self.is_solid = nil
+   StayingCharas.unregister_global(self)
 
    self:refresh_cell_on_map()
 
@@ -577,6 +580,7 @@ function IChara:revive()
    self.nutrition = 8000
    self.personal_relations = {}
    self:set_target(nil)
+   StayingCharas.unregister_global(self)
 
    -- TODO move?
    self.is_pregnant = false
@@ -659,6 +663,11 @@ function IChara:set_item_using(item)
       self.item_using = nil
    end
    self.item_using = item
+end
+
+function IChara:remove_ownership()
+   StayingCharas.unregister_global(self)
+   return IMapObject.remove_ownership(self)
 end
 
 return IChara

--- a/src/api/chara/ICharaParty.lua
+++ b/src/api/chara/ICharaParty.lua
@@ -1,5 +1,7 @@
 local Chara = require("api.Chara")
 local save = require("internal.global.save")
+local Map = require("api.Map")
+local InstancedMap = require("api.InstancedMap")
 
 local ICharaParty = class.interface("ICharaParty", {})
 

--- a/src/api/chara/ICharaParty.lua
+++ b/src/api/chara/ICharaParty.lua
@@ -130,7 +130,10 @@ function ICharaParty:can_recruit_allies()
       return false
    end
 
-   return #party.members < 16
+   local can_recruit = true
+   can_recruit = self:emit("base.on_chara_calc_can_recruit_allies", nil, can_recruit)
+
+   return can_recruit
 end
 
 return ICharaParty

--- a/src/api/gui/PositionPrompt.lua
+++ b/src/api/gui/PositionPrompt.lua
@@ -192,13 +192,11 @@ end
 function PositionPrompt:update(dt)
    if self.canceled then
       Gui.set_camera_pos(self.origin_x, self.origin_y)
-      Gui.update_screen(dt)
       return nil, "canceled"
    end
 
    if self.result then
       Gui.set_camera_pos(self.origin_x, self.origin_y)
-      Gui.update_screen(dt)
       return self.result, nil
    end
 end

--- a/src/api/gui/menu/ChooseNpcMenu.lua
+++ b/src/api/gui/menu/ChooseNpcMenu.lua
@@ -95,11 +95,11 @@ function ChooseNpcMenu:init(charas, topic)
    self.pages = UiList:new_paged(self.data, 16)
    self.custom_topic = topic or nil
    if self.custom_topic then
-      assert(type(self.custom_topic.title) == "string")
+      assert(type(self.custom_topic.header_status) == "string")
       assert(type(self.custom_topic.formatter) == "function")
    end
 
-   self.window = UiWindow:new("title", true, "hint")
+   self.window = UiWindow:new("ui.npc_list.title", true, "key help")
    table.merge(self.pages, UiListExt(self))
 
    self.chip_batch = nil
@@ -136,7 +136,7 @@ function ChooseNpcMenu:draw()
    Ui.draw_topic("ui.npc_list.info", self.x + 350, self.y + 36)
 
    if self.custom_topic then
-      Ui.draw_topic(self.custom_topic.title, self.x + 490, self.y + 36)
+      Ui.draw_topic(self.custom_topic.header_status, self.x + 490, self.y + 36)
    end
 
    self.pages:draw()

--- a/src/internal/data/events.lua
+++ b/src/internal/data/events.lua
@@ -134,5 +134,6 @@ data:add_multi(
       { _id = "on_player_death_revival" },
       { _id = "on_theme_switched" },
       { _id = "on_object_prototype_changed" },
+      { _id = "on_chara_calc_can_recruit_allies" },
    }
 )

--- a/src/internal/events/init_save.lua
+++ b/src/internal/events/init_save.lua
@@ -5,6 +5,7 @@ local UidTracker = require("api.UidTracker")
 local Rand = require("api.Rand")
 local save = require("internal.global.save")
 local parties = require("internal.parties")
+local StayingCharas = require("api.StayingCharas")
 
 local function init_save()
    local s = save.base
@@ -34,6 +35,7 @@ local function init_save()
    s.travel_last_town_name = ""
    s.is_first_turn = false
    s.inventories = {}
+   s.staying_charas = StayingCharas:new(nil)
 end
 
 Event.register("base.on_init_save", "Init save (base)", init_save, {priority = 0})

--- a/src/internal/events/map_exit.lua
+++ b/src/internal/events/map_exit.lua
@@ -56,3 +56,10 @@ local function proc_area_changed(prev_map, params)
 end
 
 Event.register("base.on_map_leave", "Events on area change", proc_area_changed, { priority = 200000 })
+
+local function transfer_staying_charas(_, params)
+   local next_map = params.next_map
+
+   save.base.staying_charas:do_transfer(next_map)
+end
+Event.register("base.on_map_leave", "Transfer staying characters", transfer_staying_charas, { priority = 300000 })

--- a/src/internal/events/map_init.lua
+++ b/src/internal/events/map_init.lua
@@ -163,7 +163,10 @@ end
 
 local function check_renew(map)
    local area = Area.for_map(map)
-   assert(area)
+   if area == nil then
+      return
+   end
+
    local area_meta = area.metadata
    -- >>>>>>>> shade2/map.hsp:2173 *check_renew ..
    if area_meta.arena_seed_renew_date and World.date_hours() >= area_meta.arena_seed_renew_date then
@@ -238,8 +241,9 @@ end
 local function proc_map_entered(map)
    -- >>>>>>>> shade2/map.hsp:286 	if gDeepest<gLevel:if gArea!areaShelter:gDeepest= ..
    local area = Area.for_map(map)
-   assert(area)
-   area.deepest_level_visited = math.max(area.deepest_level_visited, Map.floor_number(map))
+   if area then
+      area.deepest_level_visited = math.max(area.deepest_level_visited, Map.floor_number(map))
+   end
    -- <<<<<<<< shade2/map.hsp:287 	if areaDeepest(gArea)<gLevel:areaDeepest(gArea)=g ..
 
    if Map.is_world_map(map) then

--- a/src/internal/layer/shadow_layer.lua
+++ b/src/internal/layer/shadow_layer.lua
@@ -165,7 +165,7 @@ function shadow_layer:draw(draw_x, draw_y, offx, offy)
       end
    end
 
-   self.shadow_batch:draw(draw_x, draw_y, 0, 0)
+   self.shadow_batch:draw(draw_x + offy, draw_y + offy, 0, 0)
 end
 
 return shadow_layer

--- a/src/mod/base/locale/en/ui.lua
+++ b/src/mod/base/locale/en/ui.lua
@@ -62,6 +62,7 @@ end,
         prompt = "Who stays in your home?",
         title = "Ally List"
       },
+      title = "Ally List",
       waiting = "Waiting"
     },
     analysis = {

--- a/src/mod/base/locale/jp/ui.lua
+++ b/src/mod/base/locale/jp/ui.lua
@@ -59,6 +59,7 @@ return {
             prompt = "誰を滞在させる？",
             title = "滞在状態の変更"
          },
+         title = "仲間",
          waiting = "待機"
       },
       analysis = {

--- a/src/mod/elona/api/Building.lua
+++ b/src/mod/elona/api/Building.lua
@@ -228,7 +228,7 @@ function Building.query_house_board()
 
       --[[
          actions = {
-         { text = "action.interact.choices.talk", key = "a", callback = function(chara) ... end }
+         { text = "action.interact.choices.talk", key = "a", callback = function(map) ... end }
          }
       --]]
 
@@ -249,8 +249,6 @@ function Building.query_house_board()
 
       choice.callback(map)
    end
-
-   Gui.update_screen()
 
    return "player_turn_query"
    -- <<<<<<<< shade2/map_user.hsp:245  ..

--- a/src/mod/elona/api/Calc.lua
+++ b/src/mod/elona/api/Calc.lua
@@ -589,4 +589,10 @@ function Calc.calc_actual_bill_amount(chara)
    -- <<<<<<<< shade2/event.hsp:487 		iSubName(ci)=iSubName(ci)*(100+rnd(20))/100 ..
 end
 
+function Calc.calc_ally_limit(chara)
+   -- >>>>>>>> shade2/init.hsp:3174 #define global followerLimit limit(sCHR(pc)/5+1,2, ...
+   return math.floor(math.clamp(chara:skill_level("elona.stat_charisma") / 5 + 1, 2, Const.MAX_CHARAS_ALLY))
+   -- <<<<<<<< shade2/init.hsp:3174 #define global followerLimit limit(sCHR(pc)/5+1,2, ..
+end
+
 return Calc

--- a/src/mod/elona/api/ElonaBuilding.lua
+++ b/src/mod/elona/api/ElonaBuilding.lua
@@ -18,6 +18,7 @@ local ElonaBuilding = {}
 
 -- >>>>>>>> shade2/map_user.hsp:473 *shop_turn ..
 function ElonaBuilding.update_shops()
+   -- TODO multiple shop maps per area (#178)
    for _, building in ipairs(save.elona.player_owned_buildings) do
       if building.area_archetype_id == "elona.shop" then
          ElonaBuilding.update_shop(building.area_uid)
@@ -89,6 +90,7 @@ function ElonaBuilding.update_shop(area)
       return
    end
 
+   -- TODO multiple shop maps per area (#178)
    local ok, floor = area:get_floor(1)
    if not ok then
       Log.debug("Missing shop floor 1")

--- a/src/mod/elona/api/gui/MapEditLayer.lua
+++ b/src/mod/elona/api/gui/MapEditLayer.lua
@@ -156,7 +156,16 @@ local function place_tile(map, tx, ty, tile_id)
     Gui.play_sound("base.offer1")
   end
   map:set_tile(tx, ty, tile_id)
+
   map:reveal_tile(tx, ty)
+
+  -- Reveal everything surrounding also, to make sure wall tiles don't bug out.
+  for _, x, y in Pos.iter_surrounding(tx, ty) do
+     if map:is_in_bounds(x, y) then
+        map:reveal_tile(x, y)
+     end
+  end
+
   Gui.update_screen()
 end
 

--- a/src/mod/elona/events/building.lua
+++ b/src/mod/elona/events/building.lua
@@ -10,6 +10,7 @@ local Building = require("mod.elona.api.Building")
 local Chara = require("api.Chara")
 local Servant = require("mod.elona.api.Servant")
 local Home = require("mod.elona.api.Home")
+local Log = require("api.Log")
 
 local function day_passes()
    local guests = save.elona.waiting_guests
@@ -69,7 +70,13 @@ local function house_board_shop_info(map)
       return
    end
 
-   local area = assert(Area.for_map(map))
+   -- TODO multiple building maps per area (#178)
+   local area = Area.for_map(map)
+   if area == nil then
+      Log.error("Shop map '%d' is not in an area.", map.uid)
+      return
+   end
+
    local shopkeeper_uid = area.metadata.shopkeeper_uid
 
    if shopkeeper_uid then
@@ -94,6 +101,7 @@ local function house_board_ranch_info(map)
       return
    end
 
+   -- TODO multiple building maps per area (#178)
    local area = assert(Area.for_map(map))
    local breeder_uid = area.metadata.ranch_breeder_uid
 

--- a/src/mod/elona/events/building.lua
+++ b/src/mod/elona/events/building.lua
@@ -126,7 +126,7 @@ local function house_board_your_home_info(map)
       return
    end
 
-   local servants = Chara.iter_others(map):filter(Servant.is_servant):length()
+   local servants = Servant.iter(map):length()
    local max = Servant.calc_max_servant_limit(map)
 
    Gui.mes("building.home.staying.count", servants, max)

--- a/src/mod/elona/events/house_board.lua
+++ b/src/mod/elona/events/house_board.lua
@@ -6,8 +6,27 @@ local Map = require("api.Map")
 local Home = require("mod.elona.api.Home")
 local HomeRankMenu = require("mod.elona.api.gui.HomeRankMenu")
 local Servant = require("mod.elona.api.Servant")
+local MapEdit = require("mod.elona.api.MapEdit")
+local Gui = require("api.Gui")
+local Area = require("api.Area")
+local Log = require("api.Log")
+local ChooseAllyMenu = require("api.gui.menu.ChooseAllyMenu")
+local Chara = require("api.Chara")
 
 local function shop_assign_shopkeeper(map)
+   if not Building.map_is_building(map, "elona.shop") then
+      Gui.mes("common.it_is_impossible")
+      return
+   end
+
+   -- TODO multiple shop maps per area (#178)
+   local area = Area.for_map(map)
+   if area == nil then
+      Log.error("Shop map '%d' is not in an area.", map.uid)
+      Gui.mes("common.it_is_impossible")
+      return
+   end
+
 end
 
 local function shop_reform(map)
@@ -17,6 +36,7 @@ local function ranch_assign_breeder(map)
 end
 
 local function design(map)
+   MapEdit.start()
 end
 
 local function your_home_home_rank(map)

--- a/src/mod/elona/events/house_board.lua
+++ b/src/mod/elona/events/house_board.lua
@@ -12,21 +12,22 @@ local Area = require("api.Area")
 local Log = require("api.Log")
 local ChooseAllyMenu = require("api.gui.menu.ChooseAllyMenu")
 local Chara = require("api.Chara")
+local StayingCharas = require("api.StayingCharas")
+local ICharaParty = require("api.chara.ICharaParty")
+local ChooseNpcMenu = require("api.gui.menu.ChooseNpcMenu")
+local Enum = require("api.Enum")
+local Input = require("api.Input")
+
+local function iter_staying_allies()
+   return StayingCharas.iter_global():filter(ICharaParty.is_in_player_party)
+end
+
+local function iter_allies_and_stayers(map)
+   return fun.chain(Chara.player():iter_other_party_members(map), iter_staying_allies())
+end
+
 
 local function shop_assign_shopkeeper(map)
-   if not Building.map_is_building(map, "elona.shop") then
-      Gui.mes("common.it_is_impossible")
-      return
-   end
-
-   -- TODO multiple shop maps per area (#178)
-   local area = Area.for_map(map)
-   if area == nil then
-      Log.error("Shop map '%d' is not in an area.", map.uid)
-      Gui.mes("common.it_is_impossible")
-      return
-   end
-
 end
 
 local function shop_reform(map)
@@ -45,14 +46,110 @@ local function your_home_home_rank(map)
    HomeRankMenu:new(most_valuable, base_value, home_value, furniture_value):query()
 end
 
+local function format_hp(chara)
+   local percent = math.floor(chara.hp * 100 / chara:calc("max_hp"))
+   return ("(Hp: %d%%)"):format(percent)
+end
+
+local function format_info_status(chara)
+   -- >>>>>>>> shade2/command.hsp:551 			s="Lv."+cLevel(i)+" " ...
+   local status_text
+
+   -- allyCtrl=3
+   if chara.state == "PetDead" then
+      status_text = I18N.get("ui.ally_list.dead")
+   elseif chara.state == "PetWait" then
+      status_text = format_hp(chara) .. " " .. I18N.get("ui.ally_list.waiting")
+   elseif chara.state == "Alive" then
+      status_text = format_hp(chara)
+   end
+
+   return ("Lv.%d %s"):format(chara:calc("level"), status_text)
+   -- <<<<<<<< shade2/command.hsp:558 				} ..
+end
+
 local function your_home_allies(map)
+   Gui.mes("ui.ally_list.stayer.prompt")
+
+   local topic = {
+      info_formatter = format_info_status,
+      window_title = "ui.ally_list.stayer.title",
+   }
+
+   local allies = iter_allies_and_stayers(map):filter(Chara.is_alive):to_list()
+   local result, canceled = ChooseAllyMenu:new(allies, topic):query()
+
+   if result and not canceled then
+      Gui.play_sound("base.ok1")
+      Gui.mes_newline()
+      local ally = result.chara
+      local staying_map = StayingCharas.get_staying_map_for_global(ally)
+      if staying_map then
+         if staying_map.map_uid == map.uid then
+            StayingCharas.unregister_global(ally)
+            Gui.mes("building.home.staying.remove.ally", ally)
+         end
+      else
+         StayingCharas.register_global(ally, map)
+         Gui.mes("building.home.staying.add.ally", ally)
+      end
+   end
 end
 
 local function your_home_recruit_servant(map)
    Servant.query_hire()
 end
 
+local function format_wage(chara)
+   -- >>>>>>>> shade2/command.hsp:1235 		if allyCtrl=1:	s=""+(calcHireCost(i)*20)+"("+cal ...
+   local wage = Servant.calc_wage_cost(chara)
+   return I18N.get("ui.npc_list.gold_counter", ("%d"):format(wage))
+   -- <<<<<<<< shade2/command.hsp:1236 		pos wX+512,wY+66+cnt*19+2:mes s+lang(" gold","gp ..
+end
+
 local function your_home_move_stayer(map)
+   local topic = {
+      header_status = "ui.npc_list.init_cost",
+      formatter = format_wage
+   }
+
+   local candidates = Servant.iter(map):to_list()
+
+   Gui.mes("building.home.move.who")
+   local servant, canceled = ChooseNpcMenu:new(candidates, topic):query()
+
+   if servant and not canceled then
+      if servant:relation_towards(Chara.player()) <= Enum.Relation.Enemy then
+         Gui.mes("building.home.move.dont_touch_me", servant)
+      else
+         Gui.play_sound("base.ok1")
+         local pos_x = servant.x
+         local pos_y = servant.y
+         while true do
+            Gui.mes_newline()
+            Gui.mes("building.home.move.where", servant)
+            local dest_x, dest_y = Input.query_position(Chara.player(), pos_x, pos_y)
+            if dest_x == nil or dest_y == "canceled" then
+               break
+            end
+            pos_x, pos_y = dest_x, dest_y
+            if not map:can_access(dest_x, dest_y) then
+               Gui.mes("building.home.move.invalid")
+            else
+               servant:set_pos(dest_x, dest_y)
+               servant.initial_x = servant.x
+               servant.initial_y = servant.y
+               servant:remove_activity()
+               Gui.mes_newline()
+               Gui.mes("building.home.move.is_moved", servant)
+               Gui.play_sound("base.foot", servant.x, servant.y)
+               break
+            end
+         end
+      end
+   end
+
+   Gui.update_screen()
 end
 
 local function add_house_board_actions(map, params, actions)

--- a/src/mod/elona/events/map_init.lua
+++ b/src/mod/elona/events/map_init.lua
@@ -2,6 +2,9 @@ local Calc = require("mod.elona.api.Calc")
 local MapgenUtils = require("mod.elona.api.MapgenUtils")
 local Event = require("api.Event")
 local Effect = require("mod.elona.api.Effect")
+local Home = require("mod.elona.api.Home")
+local DeferredEvent = require("mod.elona_sys.api.DeferredEvent")
+local DeferredEvents = require("mod.elona.api.DeferredEvents")
 
 local function spawn_random_sites(map, params)
    local amount = Calc.calc_random_site_generate_count(map)
@@ -20,3 +23,13 @@ local function spoil_items_on_enter(map)
 end
 Event.register("base.on_map_enter", "Spoil items on enter", spoil_items_on_enter, 150000)
 -- <<<<<<<< shade2/map.hsp:2124 		} ..
+
+
+local function welcome_home(map)
+   -- >>>>>>>> shade2/system.hsp:23 	if gArea=areaHome{ ...
+   if Home.is_home(map) then
+      DeferredEvent.add(function() DeferredEvents.welcome_home(map) end)
+   end
+   -- <<<<<<<< shade2/system.hsp:28 		} ..
+end
+Event.register("base.on_map_enter", "Make servants welcome the player", welcome_home, 100000)

--- a/src/test/lib/test_util.lua
+++ b/src/test/lib/test_util.lua
@@ -12,10 +12,10 @@ local test_util = {}
 
 function test_util.set_player(map, x, y)
    if map == nil then
-      field.player = assert(Chara.create("base.player", x, y, {ownerless=true}))
+      field.player = assert(test_util.stripped_chara("base.player", nil, x, y))
       return field.player
    else
-      local player = assert(Chara.create("base.player", x, y, {}, map))
+      local player = assert(test_util.stripped_chara("base.player", map, x, y))
       Chara.set_player(player)
       return player
    end

--- a/src/test/unit/api/Chara.lua
+++ b/src/test/unit/api/Chara.lua
@@ -1,0 +1,21 @@
+local Chara = require("api.Chara")
+local test_util = require("test.lib.test_util")
+local Map = require("api.Map")
+local Assert = require("api.test.Assert")
+local save = require("internal.global.save")
+local InstancedMap = require("api.InstancedMap")
+
+function test_map_travel_transfers_staying()
+   local map = InstancedMap:new(10, 10)
+   local player = test_util.set_player(map)
+   local chara = Chara.create("elona.putit", 5, 5, {}, map)
+
+   Assert.eq(1, Chara.iter_allies(map):length())
+
+   Assert.is_truthy(player:recruit_as_ally(chara))
+   Assert.eq(2, Chara.iter_allies(map):length())
+
+   chara:kill()
+   Assert.eq("PetDead", chara.state)
+   Assert.eq(2, Chara.iter_allies(map):length())
+end

--- a/src/test/unit/api/Map.lua
+++ b/src/test/unit/api/Map.lua
@@ -1,17 +1,21 @@
 local Map = require("api.Map")
 local Area = require("api.Area")
 local Assert = require("api.test.Assert")
+local Chara = require("api.Chara")
+local StayingCharas = require("api.StayingCharas")
+local test_util = require("test.lib.test_util")
+local save = require("internal.global.save")
 
-function test_Area_position_in_parent_map()
+function test_Map_position_in_parent_map()
    local north_tyris_area = Area.create_unique("elona.north_tyris", "root")
 
    local puppy_cave_area = Area.create_unique("elona.puppy_cave", north_tyris_area)
-   local ok, first_floor = puppy_cave_area:load_or_generate_floor(puppy_cave_area:starting_floor())
+   local ok, puppy_cave_map = assert(puppy_cave_area:load_or_generate_floor(puppy_cave_area:starting_floor()))
 
    Assert.eq(true, ok)
-   Assert.is_truthy(first_floor)
+   Assert.is_truthy(puppy_cave_map)
 
-   local x, y = Map.position_in_parent_map(first_floor)
+   local x, y = Map.position_in_parent_map(puppy_cave_map)
    Assert.eq(29, x)
    Assert.eq(24, y)
 end

--- a/src/test/unit/api/StayingCharas.lua
+++ b/src/test/unit/api/StayingCharas.lua
@@ -9,18 +9,21 @@ function test_StayingCharas_register()
    local staying = StayingCharas:new()
 
    local map = InstancedMap:new(10, 10)
-   local chara = Chara.create("elona.putit", nil, nil, nil, map)
+   local chara = Chara.create("elona.putit", 2, 7, nil, map)
 
    Assert.eq(0, staying:iter():length())
-   Assert.eq(nil, staying:get_staying_map_uid_for(chara))
+   Assert.eq(nil, staying:get_staying_map_for(chara))
+   Assert.eq(false, staying:is_staying_in_map(chara, map))
 
    staying:register(chara, map)
    Assert.eq(0, staying:iter():length())
-   Assert.eq(map.uid, staying:get_staying_map_uid_for(chara))
+   Assert.eq(map.uid, staying:get_staying_map_for(chara).map_uid)
+   Assert.eq(true, staying:is_staying_in_map(chara, map))
 
    staying:unregister(chara, map)
    Assert.eq(0, staying:iter():length())
-   Assert.eq(nil, staying:get_staying_map_uid_for(chara))
+   Assert.eq(nil, staying:get_staying_map_for(chara))
+   Assert.eq(false, staying:is_staying_in_map(chara, map))
 end
 
 function test_StayingCharas_do_transfer()
@@ -28,7 +31,7 @@ function test_StayingCharas_do_transfer()
 
    local inside = InstancedMap:new(10, 10)
    local outside = InstancedMap:new(10, 10)
-   local chara = Chara.create("elona.putit", nil, nil, nil, inside)
+   local chara = Chara.create("elona.putit", 2, 7, nil, inside)
 
    staying:register(chara, inside)
 
@@ -51,6 +54,8 @@ function test_StayingCharas_do_transfer()
    Assert.eq(0, Chara.iter_all(outside):length())
    Assert.eq(0, staying:iter():length())
    Assert.eq("Alive", chara.state)
+   Assert.eq(2, chara.x)
+   Assert.eq(7, chara.y)
 end
 
 function test_StayingCharas_do_transfer__will_not_transfer_dead()
@@ -58,7 +63,7 @@ function test_StayingCharas_do_transfer__will_not_transfer_dead()
 
    local inside = InstancedMap:new(10, 10)
    local outside = InstancedMap:new(10, 10)
-   local chara = Chara.create("elona.putit", nil, nil, nil, inside)
+   local chara = Chara.create("elona.putit", 2, 7, nil, inside)
 
    staying:register(chara, inside)
    chara.state = "Dead"

--- a/src/test/unit/api/StayingCharas.lua
+++ b/src/test/unit/api/StayingCharas.lua
@@ -1,0 +1,109 @@
+local StayingCharas = require("api.StayingCharas")
+local InstancedMap = require("api.InstancedMap")
+local Chara = require("api.Chara")
+local Assert = require("api.test.Assert")
+local Map = require("api.Map")
+local test_util = require("test.lib.test_util")
+
+function test_StayingCharas_register()
+   local staying = StayingCharas:new()
+
+   local map = InstancedMap:new(10, 10)
+   local chara = Chara.create("elona.putit", nil, nil, nil, map)
+
+   Assert.eq(0, staying:iter():length())
+   Assert.eq(nil, staying:get_staying_map_uid_for(chara))
+
+   staying:register(chara, map)
+   Assert.eq(0, staying:iter():length())
+   Assert.eq(map.uid, staying:get_staying_map_uid_for(chara))
+
+   staying:unregister(chara, map)
+   Assert.eq(0, staying:iter():length())
+   Assert.eq(nil, staying:get_staying_map_uid_for(chara))
+end
+
+function test_StayingCharas_do_transfer()
+   local staying = StayingCharas:new()
+
+   local inside = InstancedMap:new(10, 10)
+   local outside = InstancedMap:new(10, 10)
+   local chara = Chara.create("elona.putit", nil, nil, nil, inside)
+
+   staying:register(chara, inside)
+
+   Assert.eq(1, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Alive", chara.state)
+
+   Assert.is_truthy(Map.try_place_chara(chara, 5, 5, outside))
+   staying:do_transfer(outside)
+
+   Assert.eq(0, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(1, staying:iter():length())
+   Assert.eq("Staying", chara.state)
+
+   staying:do_transfer(inside)
+
+   Assert.eq(1, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Alive", chara.state)
+end
+
+function test_StayingCharas_do_transfer__will_not_transfer_dead()
+   local staying = StayingCharas:new()
+
+   local inside = InstancedMap:new(10, 10)
+   local outside = InstancedMap:new(10, 10)
+   local chara = Chara.create("elona.putit", nil, nil, nil, inside)
+
+   staying:register(chara, inside)
+   chara.state = "Dead"
+
+   Assert.eq(1, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Dead", chara.state)
+
+   Assert.is_truthy(Map.try_place_chara(chara, 5, 5, outside))
+   staying:do_transfer(outside)
+
+   Assert.eq(0, Chara.iter_all(inside):length())
+   Assert.eq(1, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Dead", chara.state)
+
+   Assert.is_truthy(Map.try_place_chara(chara, 5, 5, inside))
+   staying:do_transfer(inside)
+
+   Assert.eq(1, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Dead", chara.state)
+end
+
+function test_StayingCharas_do_transfer__will_not_transfer_player()
+   local staying = StayingCharas:new()
+
+   local inside = InstancedMap:new(10, 10)
+   local outside = InstancedMap:new(10, 10)
+   local chara = test_util.set_player(inside)
+
+   staying:register(chara, inside)
+
+   Assert.eq(1, Chara.iter_all(inside):length())
+   Assert.eq(0, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Alive", chara.state)
+
+   Assert.is_truthy(Map.try_place_chara(chara, 5, 5, outside))
+   staying:do_transfer(outside)
+
+   Assert.eq(0, Chara.iter_all(inside):length())
+   Assert.eq(1, Chara.iter_all(outside):length())
+   Assert.eq(0, staying:iter():length())
+   Assert.eq("Alive", chara.state)
+end

--- a/src/test/unit/api/chara/IChara.lua
+++ b/src/test/unit/api/chara/IChara.lua
@@ -1,6 +1,8 @@
 local InstancedMap = require("api.InstancedMap")
 local Chara = require("api.Chara")
 local Assert = require("api.test.Assert")
+local StayingCharas = require("api.StayingCharas")
+local save = require("internal.global.save")
 
 function test_IChara_swap_places()
    local map = InstancedMap:new(10, 10)
@@ -22,4 +24,46 @@ function test_IChara_swap_places()
 
    ally:set_pos(0, 1)
    Assert.eq(nil, Chara.at(1, 2, map))
+end
+
+function test_IChara_kill__unregisters_staying()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local chara = Chara.create("base.player", 1, 2, {}, map)
+   StayingCharas.register_global(chara, map)
+
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+
+   chara:kill()
+
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
+end
+
+function test_IChara_vaniquish__unregisters_staying()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local chara = Chara.create("base.player", 1, 2, {}, map)
+   StayingCharas.register_global(chara, map)
+
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+
+   chara:vanquish()
+
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
+end
+
+function test_IChara_remove_ownership__unregisters_staying()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local chara = Chara.create("base.player", 1, 2, {}, map)
+   StayingCharas.register_global(chara, map)
+
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+
+   chara:remove_ownership()
+
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
 end

--- a/src/test/unit/api/chara/IChara.lua
+++ b/src/test/unit/api/chara/IChara.lua
@@ -33,11 +33,11 @@ function test_IChara_kill__unregisters_staying()
    local chara = Chara.create("base.player", 1, 2, {}, map)
    StayingCharas.register_global(chara, map)
 
-   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_for(chara).map_uid)
 
    chara:kill()
 
-   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_for(chara))
 end
 
 function test_IChara_vaniquish__unregisters_staying()
@@ -47,11 +47,11 @@ function test_IChara_vaniquish__unregisters_staying()
    local chara = Chara.create("base.player", 1, 2, {}, map)
    StayingCharas.register_global(chara, map)
 
-   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_for(chara).map_uid)
 
    chara:vanquish()
 
-   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_for(chara))
 end
 
 function test_IChara_remove_ownership__unregisters_staying()
@@ -61,9 +61,9 @@ function test_IChara_remove_ownership__unregisters_staying()
    local chara = Chara.create("base.player", 1, 2, {}, map)
    StayingCharas.register_global(chara, map)
 
-   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(map.uid, save.base.staying_charas:get_staying_map_for(chara).map_uid)
 
    chara:remove_ownership()
 
-   Assert.eq(nil, save.base.staying_charas:get_staying_map_uid_for(chara))
+   Assert.eq(nil, save.base.staying_charas:get_staying_map_for(chara))
 end

--- a/src/test/unit/event/map_exit.lua
+++ b/src/test/unit/event/map_exit.lua
@@ -1,0 +1,46 @@
+local Area = require("api.Area")
+local Chara = require("api.Chara")
+local test_util = require("test.lib.test_util")
+local Map = require("api.Map")
+local StayingCharas = require("api.StayingCharas")
+local Assert = require("api.test.Assert")
+local save = require("internal.global.save")
+
+function test_map_travel_transfers_staying()
+   local north_tyris_area = Area.create_unique("elona.north_tyris", "root")
+   local _, north_tyris_map = assert(north_tyris_area:load_or_generate_floor(north_tyris_area:starting_floor()))
+
+   local puppy_cave_area = Area.create_unique("elona.puppy_cave", north_tyris_area)
+   local _, puppy_cave_map = assert(puppy_cave_area:load_or_generate_floor(puppy_cave_area:starting_floor()))
+
+   local player = test_util.set_player(puppy_cave_map)
+   local chara = Chara.create("elona.putit", 10, 10, {}, puppy_cave_map)
+   Assert.is_truthy(player:recruit_as_ally(chara))
+   Map.set_map(puppy_cave_map)
+
+   StayingCharas.register_global(chara, puppy_cave_map)
+
+   Assert.eq("Alive", chara.state)
+   Assert.eq(puppy_cave_map, chara:get_location())
+   Assert.eq(1, chara:iter_other_party_members():length())
+
+   Assert.is_truthy(Map.travel_to(north_tyris_map))
+
+   Assert.eq("Staying", chara.state)
+   Assert.eq(save.base.staying_charas, chara:get_location())
+   Assert.eq(0, chara:iter_other_party_members():length())
+
+   Assert.is_truthy(Map.travel_to(puppy_cave_map))
+
+   Assert.eq("Alive", chara.state)
+   Assert.eq(puppy_cave_map, chara:get_location())
+   Assert.eq(1, chara:iter_other_party_members():length())
+
+   StayingCharas.unregister_global(chara)
+
+   Assert.is_truthy(Map.travel_to(north_tyris_map))
+
+   Assert.eq("Alive", chara.state)
+   Assert.eq(north_tyris_map, chara:get_location())
+   Assert.eq(1, chara:iter_other_party_members():length())
+end

--- a/src/test/unit/mod/elona/event/chara.lua
+++ b/src/test/unit/mod/elona/event/chara.lua
@@ -1,0 +1,64 @@
+local Chara = require("api.Chara")
+local Assert = require("api.test.Assert")
+local test_util = require("test.lib.test_util")
+local InstancedMap = require("api.InstancedMap")
+local StayingCharas = require("api.StayingCharas")
+local Map = require("api.Map")
+
+function test_chara_can_recruit_allies()
+   local map = InstancedMap:new(10, 10)
+   local chara = Chara.create("elona.putit", 10, 10, {}, map)
+   local player = test_util.set_player(map)
+   player:mod_base_skill_level("elona.stat_charisma", 1, "set")
+   player:refresh()
+
+   Assert.eq(true, player:can_recruit_allies())
+   Assert.eq(false, chara:can_recruit_allies())
+
+   Assert.is_truthy(player:recruit_as_ally(chara))
+
+   Assert.eq(true, player:can_recruit_allies())
+
+   local chara2 = Chara.create("elona.putit", 10, 10, {}, map)
+   Assert.is_truthy(player:recruit_as_ally(chara2))
+
+   Assert.eq(false, player:can_recruit_allies())
+
+   local chara3 = Chara.create("elona.putit", 10, 10, {}, map)
+   Assert.is_falsy(player:recruit_as_ally(chara3))
+end
+
+function test_chara_can_recruit_allies_stayers()
+   local map = InstancedMap:new(10, 10)
+   local chara = Chara.create("elona.putit", 10, 10, {}, map)
+   local player = test_util.set_player(map)
+   player:mod_base_skill_level("elona.stat_charisma", 1, "set")
+   player:refresh()
+   Map.set_map(map)
+
+   Assert.is_truthy(player:recruit_as_ally(chara))
+
+   local chara2 = Chara.create("elona.putit", 10, 10, {}, map)
+   Assert.is_truthy(player:recruit_as_ally(chara2))
+
+   Assert.eq(2, player:iter_other_party_members(map):length())
+   Assert.eq(false, player:can_recruit_allies())
+
+   local outside = InstancedMap:new(10, 10)
+   StayingCharas.register_global(chara, map)
+   StayingCharas.register_global(chara2, map)
+
+   Assert.is_truthy(Map.travel_to(outside))
+
+   Assert.eq("Staying", chara.state)
+   Assert.eq("Staying", chara2.state)
+   Assert.eq(0, player:iter_other_party_members(map):length())
+   Assert.eq(false, player:can_recruit_allies())
+
+   Assert.is_truthy(Map.travel_to(map))
+
+   Assert.eq("Alive", chara.state)
+   Assert.eq("Alive", chara2.state)
+   Assert.eq(2, player:iter_other_party_members(map):length())
+   Assert.eq(false, player:can_recruit_allies())
+end


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [ ] Enhancement
- [x] New feature

### Description
Implements allies staying home and moving servants around.

The stayers feature had to be designed the way it is because: when you want to assign a breeder or shopkeeper, vanilla will give you a list of allies to choose from including the ones assigned to a shop or ranch already. Before, in ON the shopkeeper was saved in the map's area, but this meant there was no easy way to get the list of busy characters without looping through their maps and loading them all. Now the busy characters are stored in a global pool as part of the base save, and are moved to and from there when the map changes.