### PR TITLE
Properly reinstantiate items when they're deserialized

### DIFF
--- a/src/.luacheckrc
+++ b/src/.luacheckrc
@@ -50,6 +50,8 @@ files["scratch/**/*.lua"].ignore = {
 }
 files["test/unit/**/*.lua"] = {
    globals = {
+      "save",
+      "config",
       "disable"
    },
    ignore = {

--- a/src/api/Chara.lua
+++ b/src/api/Chara.lua
@@ -261,7 +261,6 @@ function Chara.create(id, x, y, params, where)
       chara:refresh()
    end
 
-   chara:instantiate()
    chara:emit("base.on_chara_generated")
 
    return chara

--- a/src/api/Feat.lua
+++ b/src/api/Feat.lua
@@ -143,8 +143,6 @@ function Feat.create(id, x, y, params, where)
 
    MapObject.finalize(feat, gen_params)
 
-   feat:instantiate()
-
    feat:refresh()
 
    return feat

--- a/src/api/IObject.lua
+++ b/src/api/IObject.lua
@@ -1,5 +1,6 @@
 --- @module IObject
 
+local IEventEmitter = require("api.IEventEmitter")
 local IModDataHolder = require("api.IModDataHolder")
 local IModdable = require("api.IModdable")
 local data = require("internal.data")
@@ -48,8 +49,10 @@ function IObject:finalize(build_params)
 end
 
 function IObject:instantiate()
-   self:emit("base.on_object_instantiated")
-   self:emit("base.on_object_prototype_changed", {old_id=nil})
+   if class.is_an(IEventEmitter, self) then
+      self:emit("base.on_object_instantiated")
+      self:emit("base.on_object_prototype_changed", {old_id=nil})
+   end
 end
 
 function IObject:clone_base(owned)
@@ -71,7 +74,9 @@ function IObject:change_prototype(new_id)
    local mt = getmetatable(self)
    local old_id = mt._id
    mt._id = new_id
-   self:emit("base.on_object_prototype_changed", {old_id=old_id})
+   if class.is_an(IEventEmitter, self) then
+      self:emit("base.on_object_prototype_changed", {old_id=old_id})
+   end
 end
 
 return IObject

--- a/src/api/Item.lua
+++ b/src/api/Item.lua
@@ -138,8 +138,7 @@ function Item.create(id, x, y, params, where)
 
    MapObject.finalize(item, gen_params)
 
-   item:instantiate()
-   item:emit("base.on_generate", params)
+   item:emit("base.on_item_generate", params)
 
    -- >>>>>>>> shade2/item.hsp:728 	if initNum!0:iNum(ci)=initNum ..
    if type(params.amount) == "number" then

--- a/src/api/Map.lua
+++ b/src/api/Map.lua
@@ -5,6 +5,7 @@
 --- map by omitting this argument.
 ---
 --- @module Map
+local object = require("internal.object")
 
 local field = require("game.field")
 local Chara = require("api.Chara")
@@ -104,6 +105,8 @@ end
 function Map.load(uid)
    assert(type(uid) == "number")
 
+   object.clear_last_deserialized_objects()
+
    local path = Fs.join("map", tostring(uid))
    Log.debug("Loading map %d from %s", uid, path)
    local success, map = SaveFs.read(path, "temp")
@@ -112,6 +115,14 @@ function Map.load(uid)
    end
 
    map:emit("base.on_map_loaded")
+
+   -- Instantiate every object that was loaded by the deserializer, to ensure
+   -- things like event handlers that get loaded from the prototype are
+   -- restored.
+   local deserialized = object.get_last_deserialized_objects()
+   for _, obj in ipairs(deserialized) do
+      obj:instantiate()
+   end
 
    return success, map
 end

--- a/src/api/Mef.lua
+++ b/src/api/Mef.lua
@@ -133,8 +133,6 @@ function Mef.create(id, x, y, params, where)
 
    MapObject.finalize(mef, gen_params)
 
-   mef:instantiate()
-
    mef:refresh()
 
    return mef

--- a/src/api/Object.lua
+++ b/src/api/Object.lua
@@ -94,6 +94,7 @@ function Object.finalize(obj, params)
    if not params.no_build then
       obj:normal_build()
       obj:finalize(params.build_params)
+      obj:instantiate()
    end
 end
 

--- a/src/api/chara/IChara.lua
+++ b/src/api/chara/IChara.lua
@@ -564,6 +564,8 @@ function IChara:vanquish()
    end
 
    self:emit("base.on_chara_vanquished")
+
+   self:remove_ownership()
 end
 
 --- Revives this character.

--- a/src/internal/data/events.lua
+++ b/src/internal/data/events.lua
@@ -67,7 +67,7 @@ data:add_multi(
       { _id = "on_activity_finish" },
       { _id = "on_activity_interrupt" },
       { _id = "on_activity_cleanup" },
-      { _id = "on_generate" },
+      { _id = "on_item_generate" },
       { _id = "before_hotload_prototype" },
       { _id = "on_hotload_prototype" },
       { _id = "on_chara_generated" },

--- a/src/internal/events/on_hotload.lua
+++ b/src/internal/events/on_hotload.lua
@@ -30,26 +30,6 @@ Event.register("base.on_object_prototype_changed", "reload events for object", f
                   end
 end)
 
-Event.register("base.on_map_loaded", "init all event callbacks",
-               function(map)
-                  local objs = map:iter():to_list()
-                  while #objs > 0 do
-                     local v = objs[#objs]
-                     objs[#objs] = nil
-
-                     -- Event callbacks will not be serialized since
-                     -- they are functions, so they have to be copied
-                     -- from the prototype each time.
-                     if class.is_an(IEventEmitter, v) then
-                        IEventEmitter.init(v)
-                     end
-                     v:instantiate()
-                     if class.is_an(ILocation, v) then
-                        table.append(objs, v:iter():to_list())
-                     end
-                  end
-               end)
-
 Event.register("base.on_hotload_end", "Notify objects in map of prototype hotload",
                function(_, params)
                   local map = Map.current()
@@ -76,6 +56,7 @@ Event.register("base.on_hotload_end", "Notify objects in map of prototype hotloa
                               and hotloaded[thing._type][thing._id]
                            then
                               Log.debug("Load " .. thing._type .. " " .. thing._id)
+                              thing:instantiate()
                               thing:emit("base.on_hotload_object", params)
                            end
 

--- a/src/internal/object.lua
+++ b/src/internal/object.lua
@@ -162,6 +162,11 @@ function object.serialize(self)
    return ret
 end
 
+-- This is a hack so we can ensure everything that gets deserialized will have
+-- 'base.on_object_instantiated' called on it, no matter if it's in the map or
+-- inside a container in `save`.
+local _FOUND_OBJECTS = {}
+
 function object.deserialize(self, _type, _id)
    if self._type and self._id then
       _type = self._type
@@ -228,7 +233,20 @@ function object.deserialize(self, _type, _id)
       __inspect = object.__inspect
    }
 
-   return setmetatable(self, mt)
+   local obj = setmetatable(self, mt)
+   _FOUND_OBJECTS[#_FOUND_OBJECTS+1] = obj
+
+   return obj
+end
+
+function object.clear_last_deserialized_objects()
+   _FOUND_OBJECTS = {}
+end
+
+function object.get_last_deserialized_objects()
+   local result = _FOUND_OBJECTS
+   _FOUND_OBJECTS = {}
+   return result
 end
 
 function object:__tostring()

--- a/src/internal/object.lua
+++ b/src/internal/object.lua
@@ -97,56 +97,7 @@ function object.__newindex(t, k, v)
    rawset(t, k, v)
 end
 
--- TODO remove this, we should always refer to the prototype for function
--- callbacks instead of copying them to the object instance itself.
-local function extract_functions(instance, serial, proto, cache)
-   if type(proto) ~= "table" then
-      return
-   end
-
-   -- protect against recursive tables
-   if cache[instance] or cache[proto] then
-      return
-   end
-   cache[instance] = true
-   cache[proto] = true
-
-   for k, v in pairs(instance) do
-      if type(k) == "string" then
-         if type(v) == "function" and proto[k] == v then
-            serial[k] = "copy_from_proto"
-         elseif type(v) == "table" and type(instance) == "table" then
-            serial[k] = {}
-            extract_functions(serial[k], v, proto[k], cache)
-         end
-      end
-   end
-end
-
-local function copy_functions(instance, serial, proto, cache)
-   if type(proto) ~= "table" then
-      return
-   end
-
-   -- protect against recursive tables
-   if cache[instance] or cache[proto] then
-      return
-   end
-   cache[instance] = true
-   cache[proto] = true
-
-   for k, v in pairs(serial) do
-      if v == "copy_from_proto" then
-         instance[k] = proto[k]
-      elseif type(v) == "table" and type(instance[k]) == "table" then
-         copy_functions(instance[k], v, proto[k], cache)
-      end
-   end
-end
-
 function object.serialize(self)
-   local proto = self.proto
-
    local ret = object.make_prototype(self)
    assert(ret._id, "serialization currently assumes there is a prototype in data[] to load")
 
@@ -156,9 +107,6 @@ function object.serialize(self)
    ret.uid = self.uid
    assert(ret.location == nil)
 
-   local serial = {}
-   extract_functions(self, serial, proto, {})
-   ret.__serial = serial
    return ret
 end
 
@@ -202,16 +150,6 @@ function object.deserialize(self, _type, _id)
    end
    local iface = data[_type]:interface()
    assert(iface)
-
-   -- functions on the prototype table are not serialized, so they
-   -- must be copied from the prototype to the instance on
-   -- deserialization if they were unchanged from the prototype's
-   -- version on save.
-   local serial = self.__serial
-   if serial then
-      self.__serial = nil
-      copy_functions(self, serial, proto, {})
-   end
 
    local mt = {
       _id = _id,

--- a/src/mod/base/locale/en/talk_npc.lua
+++ b/src/mod/base/locale/en/talk_npc.lua
@@ -391,7 +391,7 @@ end
             yes = "Yes."
           },
           prompt = function(_1)
-  return ("(%s looks at you sadly. Really dismiss %s? )")
+  return ("(%s looks at you sadly. Really dismiss %s?)")
   :format(name(_1), him(_1))
 end,
           you_dismiss = function(_1)

--- a/src/mod/ceri_items/init.lua
+++ b/src/mod/ceri_items/init.lua
@@ -69,7 +69,7 @@ local function set_item_image_on_generate(obj, params)
    end
 end
 
-Event.register("base.on_generate", "Set item image to FFHP override", set_item_image_on_generate)
+Event.register("base.on_item_generate", "Set item image to FFHP override", set_item_image_on_generate)
 
 local function set_item_images(map)
    for _, item in Item.iter_in_everything(map) do

--- a/src/mod/elona/api/Calc.lua
+++ b/src/mod/elona/api/Calc.lua
@@ -268,25 +268,18 @@ function Calc.calc_trainer_skills(trainer, player)
    return skills
 end
 
-function Calc.calc_tax_multiplier(player)
-   -- >>>>>>>> shade2/calculation.hsp:710 #define calcAccountant 	cost=cost * limit(100-limi ..
-   local karma = player:calc("karma")
-   local tax_trait_level = player:trait_level("elona.tax")
-   return math.clamp(100 - math.clamp(karma/2, 0, 50) - (7 * tax_trait_level) - (((karma >= Const.KARMA_GOOD) and 5) or 0), 25, 200) / 100
-   -- <<<<<<<< shade2/calculation.hsp:710 #define calcAccountant 	cost=cost * limit(100-limi ..
-end
-
-function Calc.calc_building_taxes(player)
+function Calc.calc_building_expenses(player)
+   -- >>>>>>>> shade2/calculation.hsp:719 #defcfunc calcCostBuilding ...
    local cost = 0
 
-   cost = cost + save.elona.home_rank ^ 2 * 200
+   local scale = data["elona.home"]:ensure(save.elona.home_rank).properties.home_scale or 0
+   cost = cost + scale ^ 2 * 200
    for _, building in ipairs(save.elona.player_owned_buildings) do
-      cost = cost + building.tax_cost
+      cost = cost + (building.tax_cost or 0)
    end
 
-   cost = cost * Calc.calc_tax_multiplier(player)
-
-   return cost
+   return Calc.calc_adjusted_expense(cost, player)
+   -- <<<<<<<< shade2/calculation.hsp:730 	return cost ..
 end
 
 function Calc.calc_living_weapon_required_exp(level)
@@ -547,18 +540,6 @@ function Calc.calc_adjusted_expense(cost, player)
 
    return math.floor(cost * factor / 100)
    -- <<<<<<<< shade2/calculation.hsp:706 #define calcAccountant 	cost=cost * limit(100-limi ..
-end
-
-function Calc.calc_building_expenses(chara)
-   chara = chara or Chara.player()
-
-   -- >>>>>>>> shade2/calculation.hsp:719 #defcfunc calcCostBuilding ...
-   local cost = 0
-
-   -- TODO building
-
-   return Calc.calc_adjusted_expense(cost, chara)
-   -- <<<<<<<< shade2/calculation.hsp:730 	return cost ..
 end
 
 function Calc.calc_tax_expenses(chara)

--- a/src/mod/elona/api/Calc.lua
+++ b/src/mod/elona/api/Calc.lua
@@ -272,7 +272,8 @@ function Calc.calc_building_expenses(player)
    -- >>>>>>>> shade2/calculation.hsp:719 #defcfunc calcCostBuilding ...
    local cost = 0
 
-   local scale = data["elona.home"]:ensure(save.elona.home_rank).properties.home_scale or 0
+   local home = data["elona.home"]:ensure(save.elona.home_rank)
+   local scale = home.home_scale or 0
    cost = cost + scale ^ 2 * 200
    for _, building in ipairs(save.elona.player_owned_buildings) do
       cost = cost + (building.tax_cost or 0)

--- a/src/mod/elona/api/HomeMap.lua
+++ b/src/mod/elona/api/HomeMap.lua
@@ -21,9 +21,9 @@ data:add {
    map = "home0",
    value = value(0),
    image = "elona.feat_area_your_dungeon",
+   home_scale = 0,
 
    properties = {
-      home_scale = 0,
       item_on_floor_limit = 100,
       home_rank_points = 1000
    },
@@ -60,10 +60,10 @@ data:add {
    map = "home1",
    value = value(1),
    image = "elona.feat_area_town",
+   home_scale = 1,
 
    -- >>>>>>>> shade2/map_user.hsp:7 	if gHomeLevel=1{ ..
    properties = {
-      home_scale = 1,
       item_on_floor_limit = 150,
       home_rank_points = 3000
    },
@@ -76,10 +76,10 @@ data:add {
 
    map = "home2",
    value = value(2),
+   home_scale = 2,
 
    -- >>>>>>>> shade2/map_user.hsp:11 	if gHomeLevel=2{ ..
    properties = {
-      home_scale = 2,
       item_on_floor_limit = 200,
       home_rank_points = 5000
    },
@@ -92,10 +92,10 @@ data:add {
 
    map = "home3",
    value = value(3),
+   home_scale = 3,
 
    -- >>>>>>>> shade2/map_user.hsp:15 	if gHomeLevel=3{ ..
    properties = {
-      home_scale = 3,
       item_on_floor_limit = 300,
       home_rank_points = 7000
    },
@@ -109,10 +109,10 @@ data:add {
    map = "home4",
    value = value(4),
    image = "elona.feat_area_tent",
+   home_scale = 4,
 
    -- >>>>>>>> shade2/map_user.hsp:19 	if gHomeLevel=4{ ..
    properties = {
-      home_scale = 4,
       item_on_floor_limit = 350,
       home_rank_points = 8000,
       tileset = "elona.sf"
@@ -129,10 +129,10 @@ data:add {
    value = value(5) * 2,
    -- <<<<<<<< shade2/item.hsp:648 		if iParam1(ci)=5:iValue(ci)*=2 ..
    image = "elona.feat_area_castle",
+   home_scale = 5,
 
    -- >>>>>>>> shade2/map_user.hsp:24 	if gHomeLevel=5{ ..
    properties = {
-      home_scale = 0,
       item_on_floor_limit = 100,
       home_rank_points = 1000
    },

--- a/src/mod/elona/api/Servant.lua
+++ b/src/mod/elona/api/Servant.lua
@@ -142,7 +142,8 @@ function Servant.iter(map)
 end
 
 function Servant.calc_max_servant_limit(map)
-   return (map.home_scale or 0) + 2
+   local home = data["elona.home"]:ensure(save.elona.home_rank)
+   return (home.home_scale or 0) + 2
 end
 
 -- TODO support multiple homes

--- a/src/mod/elona/data/dialog/init.lua
+++ b/src/mod/elona/data/dialog/init.lua
@@ -25,6 +25,7 @@ data:add {
 require("mod.elona.data.dialog.special.default")
 require("mod.elona.data.dialog.special.quest_giver")
 require("mod.elona.data.dialog.special.sex")
+require("mod.elona.data.dialog.special.servant")
 
 require("mod.elona.data.dialog.role.guard")
 require("mod.elona.data.dialog.role.prostitute")

--- a/src/mod/elona/data/dialog/special/servant.lua
+++ b/src/mod/elona/data/dialog/special/servant.lua
@@ -1,0 +1,34 @@
+local DeferredEvent = require("mod.elona_sys.api.DeferredEvent")
+local Event = require("api.Event")
+local Dialog = require("mod.elona_sys.dialog.api.Dialog")
+local Gui = require("api.Gui")
+local Servant = require("mod.elona.api.Servant")
+
+data:add {
+   _type = "elona_sys.dialog",
+   _id = "servant",
+
+   nodes = {
+      fire_confirm = {
+         text = "talk.npc.servant.fire.prompt",
+         choices = {
+            {"fire", "talk.npc.servant.fire.choices.yes"},
+            {"elona.default:__start", "talk.npc.servant.fire.choices.no"}
+         }
+      },
+      fire = function(t)
+         -- >>>>>>>> shade2/chat.hsp:2750 			txt lang(""+name(tc)+"を解雇した… ","You dismiss "+n ...
+         Gui.mes("talk.npc.servant.fire.you_dismiss", t.speaker)
+         t.speaker:vanquish()
+         -- <<<<<<<< shade2/chat.hsp:2753 			goto *chat_end ..
+      end
+   }
+}
+
+local function fire_servant_choice(speaker, params, result)
+   if Servant.is_servant(speaker) and not DeferredEvent.is_pending() then
+      Dialog.add_choice("elona.servant:fire_confirm", "talk.npc.servant.choices.fire", result)
+   end
+   return result
+end
+Event.register("elona.calc_dialog_choices", "Add choice to fire servant", fire_servant_choice, { priority = 100000 })

--- a/src/mod/elona/events/house_board.lua
+++ b/src/mod/elona/events/house_board.lua
@@ -205,7 +205,7 @@ local function your_home_move_stayer(map)
       formatter = format_wage
    }
 
-   local candidates = Servant.iter(map):to_list()
+   local candidates = Servant.iter(map):filter(Chara.is_alive):to_list()
 
    Gui.mes("building.home.move.who")
    local servant, canceled = ChooseNpcMenu:new(candidates, topic):query()

--- a/src/mod/elona_sys/event/instantiate_feat.lua
+++ b/src/mod/elona_sys/event/instantiate_feat.lua
@@ -1,13 +1,5 @@
 local Event = require("api.Event")
 local Feat = require("api.Feat")
-local IFeat = require("api.feat.IFeat")
-
-local function reload_feat_events(obj)
-   if class.is_an(IFeat, obj) then
-      obj:instantiate()
-   end
-end
-Event.register("base.on_hotload_object", "reload events for feat", reload_feat_events)
 
 local actions = {
    "bash",                 -- on_bash,                 can_bash,                 elona_sys.on_feat_bash

--- a/src/mod/elona_sys/event/instantiate_item.lua
+++ b/src/mod/elona_sys/event/instantiate_item.lua
@@ -1,12 +1,4 @@
-local IItem = require("api.item.IItem")
 local Event = require("api.Event")
-
-local function reload_item_events(obj)
-   if class.is_an(IItem, obj) then
-      obj:instantiate()
-   end
-end
-Event.register("base.on_hotload_object", "reload events for item", reload_item_events)
 
 -- This is where the callbacks on item prototypes
 -- like "on_use" and "on_drink" get used. It might

--- a/src/test/unit/mod/elona/api/Calc.lua
+++ b/src/test/unit/mod/elona/api/Calc.lua
@@ -3,6 +3,9 @@ local Rand = require("api.Rand")
 local Assert = require("api.test.Assert")
 local test_util = require("test.lib.test_util")
 local Rank = require("mod.elona.api.Rank")
+local save = require("internal.global.save")
+local Area = require("api.Area")
+local Building = require("mod.elona.api.Building")
 
 function test_Calc_calc_fame_income()
    local chara = test_util.stripped_chara("elona.putit")
@@ -46,6 +49,32 @@ function test_Calc_calc_rank_income_items()
    Assert.eq(3, #Calc.calc_rank_income_items("elona.arena"))
 end
 
+function test_Calc_calc_building_expenses()
+   local north_tyris_area = Area.create_unique("elona.north_tyris", "root")
+   local ok, north_tyris_map = assert(north_tyris_area:load_or_generate_floor(north_tyris_area:starting_floor()))
+
+   local chara = test_util.stripped_chara("elona.putit")
+   Assert.eq(0, Calc.calc_building_expenses(chara))
+
+   save.elona.home_rank = "elona.cyber_house"
+   Assert.eq(1600, Calc.calc_building_expenses(chara))
+
+   Building.build("elona.storage_house", 50, 23, north_tyris_map)
+   Assert.eq(1975, Calc.calc_building_expenses(chara))
+
+   Building.build("elona.dungeon", 50, 24, north_tyris_map)
+   Assert.eq(1975, Calc.calc_building_expenses(chara))
+
+   Building.build("elona.shop", 50, 25, north_tyris_map)
+   Assert.eq(4475, Calc.calc_building_expenses(chara))
+
+   chara.karma = 30
+   Assert.eq(4027, Calc.calc_building_expenses(chara))
+
+   chara:modify_trait_level("elona.tax", 1)
+   Assert.eq(3401, Calc.calc_building_expenses(chara))
+end
+
 function test_Calc_calc_actual_bill_amount()
    local chara = test_util.stripped_chara("elona.putit")
    chara.level = 1
@@ -70,4 +99,8 @@ function test_Calc_calc_actual_bill_amount()
    chara:modify_trait_level("elona.tax", 1)
    Rand.set_seed(0)
    Assert.eq(1978, Calc.calc_actual_bill_amount(chara))
+
+   chara.karma = 30
+   Rand.set_seed(0)
+   Assert.eq(1748, Calc.calc_actual_bill_amount(chara))
 end

--- a/src/test/unit/mod/elona/api/Servant.lua
+++ b/src/test/unit/mod/elona/api/Servant.lua
@@ -59,6 +59,13 @@ function test_Servant_is_servant__story_charas()
    Assert.eq(false, Servant.is_servant(larnneire))
 end
 
+function test_Servant_calc_max_servant_limit()
+   Assert.eq(2, Servant.calc_max_servant_limit())
+
+   save.elona.home_rank = "elona.small_castle"
+   Assert.eq(7, Servant.calc_max_servant_limit())
+end
+
 function test_Servant_calc_total_labor_expenses()
    local north_tyris_area = Area.create_unique("elona.north_tyris", "root")
 


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

Closes #182.

### Description
Ensures that `IObject:instantiate()` gets called on every (map) object that gets deserialized by `save_store.load()` and `Map.load()`, for things like reconnecting event handlers.