### PR TITLE
Fix item stacking

### DIFF
--- a/src/api/Action.lua
+++ b/src/api/Action.lua
@@ -136,7 +136,13 @@ function Action.get(chara, item, amount)
       item = items[#items]
    end
 
-   return item:emit("base.on_get_item", {chara=chara,amount=amount}, false)
+   local result = item:emit("base.on_get_item", {chara=chara,amount=amount}, false)
+
+   if result then
+      item:stack(true)
+   end
+
+   return result
 end
 
 --- @tparam IChara chara
@@ -151,6 +157,7 @@ function Action.drop(chara, item, amount)
    local dropped = chara:drop_item(item, amount)
    if dropped then
       dropped:emit("base.on_drop_item", {chara=chara,amount=amount})
+      dropped:stack()
       Gui.mes("action.drop.execute", item:build_name(amount))
       Gui.play_sound("base.drop1", chara.x, chara.y)
       chara:refresh_weight()
@@ -167,6 +174,10 @@ end
 --- @treturn[2] string turn_result
 function Action.take_from_container(chara, item, amount, container_item)
    local result = item:emit("base.on_get_item", {chara=chara,amount=amount,source=item:get_location()}, false)
+
+   if result then
+      item:stack(true)
+   end
 
    if container_item then
       container_item:emit("base.after_container_provide_item", {chara=chara,item=item,amount=amount})

--- a/src/api/IComparable.lua
+++ b/src/api/IComparable.lua
@@ -1,0 +1,1 @@
+return class.interface("IComparable", { compare = "function" })

--- a/src/api/IEventEmitter.lua
+++ b/src/api/IEventEmitter.lua
@@ -10,11 +10,6 @@ local IEventEmitter = class.interface("IEventEmitter")
 function IEventEmitter:init(events)
    self._events = EventHolder:new()
    self.global_events = EventHolder:new()
-
-   local events = events or (self.proto and self.proto.events)
-   if events then
-      self:connect_self_multiple(events, true)
-   end
 end
 
 function IEventEmitter:on_reload_prototype(old_id)
@@ -29,7 +24,7 @@ function IEventEmitter:on_reload_prototype(old_id)
 
    local events = self.proto and self.proto.events
    if events then
-      Log.debug("Hotloading %d events of %s:%s for object %d", #events, self._type, self._id, self.uid)
+      Log.debug("Loading %d events of %s:%s for object %d", #events, self._type, self._id, self.uid)
       self:connect_self_multiple(events, true)
    end
 end
@@ -207,7 +202,7 @@ function IEventEmitter:connect_global(event_id, name, cb, opts, global_events)
 end
 
 function IEventEmitter:compare_events(other)
-   return self._events == other._events and self.global_events == other.global_events
+   return self._events:compare(other._events)
 end
 
 function IEventEmitter:list_events(event_id)

--- a/src/api/IStackableObject.lua
+++ b/src/api/IStackableObject.lua
@@ -65,7 +65,9 @@ function IStackableObject:can_stack_with(other)
    if not class.is_an(IStackableObject, other) then
       return false
    end
-   return self._type == other._type and self.uid ~= other.uid
+   return self._type == other._type
+      and self.uid ~= other.uid
+      and self.location == other.location
 end
 
 --- Stacks this object with other objects in the same location that

--- a/src/api/InstancedMap.lua
+++ b/src/api/InstancedMap.lua
@@ -674,11 +674,11 @@ end
 
 local function set_events_on_self(map)
    local archetype = map:archetype()
-   if archetype == nil then
+   if archetype == nil or archetype.events == nil then
       return
    end
 
-   IEventEmitter.init(map, archetype.events)
+   map:connect_self_multiple(archetype.events, true)
 end
 
 function InstancedMap:deserialize()

--- a/src/api/MapObject.lua
+++ b/src/api/MapObject.lua
@@ -238,8 +238,8 @@ function MapObject.clone(obj, owned, uid_tracker, cache, uid_mapping, opts)
       assert(location:take_object(new_object, x, y))
    end
 
-   Event.trigger("base.on_object_cloned", {object=obj, type="full", owned=owned})
-   obj:instantiate()
+   Event.trigger("base.on_object_cloned", {object=obj, new_object=new_object, type="full", owned=owned})
+   new_object:instantiate()
 
    return new_object
 end

--- a/src/api/ModExtTable.lua
+++ b/src/api/ModExtTable.lua
@@ -21,6 +21,10 @@ function ModExtTable:get_mod_data(mod_id)
    return self._store[mod_id]
 end
 
+function ModExtTable:iter()
+   return next, self._store, nil
+end
+
 function ModExtTable:serialize()
    local dead = {}
    for mod_id, store in pairs(self._store) do
@@ -32,6 +36,34 @@ function ModExtTable:serialize()
 end
 
 function ModExtTable:deserialize()
+end
+
+function ModExtTable:compare(other)
+   local found = {}
+
+   for mod_id, _ in self:iter() do
+      found[mod_id] = false
+   end
+
+   for mod_id, their_store in other:iter() do
+      if not found[mod_id] then
+         found[mod_id] = true
+         local my_store = self._store[mod_id]
+         if not table.deepcompare(my_store, their_store) then
+            return false, mod_id
+         end
+      else
+         return false, mod_id
+      end
+   end
+
+   for mod_id, was_found in pairs(found) do
+      if was_found == false then
+         return false, mod_id
+      end
+   end
+
+   return true
 end
 
 return ModExtTable

--- a/src/api/chara/ICharaEquip.lua
+++ b/src/api/chara/ICharaEquip.lua
@@ -154,6 +154,7 @@ function ICharaEquip:unequip_item(item)
    end
 
    local result = self:take_item(item)
+   item:stack()
    item:refresh()
 
    return result

--- a/src/mod/autopickup/api/Autopickup.lua
+++ b/src/mod/autopickup/api/Autopickup.lua
@@ -176,7 +176,7 @@ end
 
 function Autopickup.can_autopickup(item)
    -- >>>>>>>> oomSEST/src/southtyris.hsp:82445 		if (iNumber(cnt) > 0) { ...
-   return Item.is_alive(item) and item:calc("own_state") <= Enum.OwnState.NotOwned
+   return Item.is_alive(item) and item:calc("own_state") < Enum.OwnState.NotOwned
    -- <<<<<<<< oomSEST/src/southtyris.hsp:82446 			if (iOwnState(cnt) < 1) { ..
 end
 

--- a/src/mod/elona/api/ElonaItem.lua
+++ b/src/mod/elona/api/ElonaItem.lua
@@ -484,6 +484,8 @@ function ElonaItem.open_chest(item, gen_filter_cb, item_count, loot_level, seed,
       Item.create("elona.small_medal", x, y, { amount = 1 }, map)
    end
 
+   item:stack()
+
    Save.queue_autosave()
    -- <<<<<<<< shade2/action.hsp:1022 	iParam1(ri)=0 ..
 end

--- a/src/mod/elona/api/LootDrops.lua
+++ b/src/mod/elona/api/LootDrops.lua
@@ -402,9 +402,8 @@ function LootDrops.calc_loot_drops(chara, map, attacker)
       drops[#drops+1] = { _id = "elona.corpse", on_create = LootDrops.make_corpse }
    end
 
-   if false
-      -- or config.base.development_mode
-   then
+   --[[
+   if config.base.development_mode then
       drops[#drops+1] = {
          filter = {
             categories = "elona.remains"
@@ -412,6 +411,7 @@ function LootDrops.calc_loot_drops(chara, map, attacker)
          on_create = LootDrops.make_remains
       }
    end
+   --]]
 
    local rich_loot = chara:calc("rich_loot_amount")
    if rich_loot and rich_loot > 0 then
@@ -455,6 +455,7 @@ function LootDrops.do_drop_loot(chara, map, attacker, drops)
          if drop.on_create then
             drop.on_create(item, chara, attacker)
          end
+         item:stack()
       end
    end
 

--- a/src/mod/elona/data/activity.lua
+++ b/src/mod/elona/data/activity.lua
@@ -1247,7 +1247,7 @@ data:add {
 
             -- TODO: shade2/proc.hsp:3118 ((iId(ci)=idMageBook)&(iParam2(ci)!0))
 
-            self.params.ancient_book:stack()
+            self.params.ancient_book:stack(true)
             -- <<<<<<<< shade2/proc.hsp:1228 		item_stack pc,ci,1 ..
          end
       }
@@ -1662,6 +1662,7 @@ data:add {
                chara.gold = chara.gold + 1
             else
                assert(chara:take_item(sep))
+               sep:stack(true)
                Gui.play_sound(Rand.choice({"base.get1", "base.get2"}), chara.x, chara.y)
             end
             chara:refresh_weight()

--- a/src/mod/elona/data/activity/fishing.lua
+++ b/src/mod/elona/data/activity/fishing.lua
@@ -11,7 +11,7 @@ local function get_fish(chara, fishing_pole)
    local fish = Fishing.create_fish(fish_id, chara)
    if fish then
       Gui.mes("activity.fishing.get", fish:build_name(1))
-      fish:stack()
+      fish:stack(true)
    end
    return fish
    -- <<<<<<<< shade2/proc.hsp:883 	return ..

--- a/src/mod/elona/data/inventory_proto.lua
+++ b/src/mod/elona/data/inventory_proto.lua
@@ -356,6 +356,7 @@ function inv_give.on_select(ctxt, item, amount)
 
    local sep = item:separate(1)
    sep:remove_ownership()
+   ElonaItem.ensure_free_item_slot(target)
    assert(target:take_item(sep))
    sep:stack(true)
 
@@ -942,6 +943,7 @@ local inv_put_food_container = {
       -- >>>>>>>> shade2/command.hsp:3421 		if invCtrl(1)=3: if refType!fltFood:continue ...
          and item:has_category("elona.food")
       -- <<<<<<<< shade2/command.hsp:3421 		if invCtrl(1)=3: if refType!fltFood:continue ..
+         and not item:is_item_container()
    end,
 
    on_select = function(ctxt, item, amount)

--- a/src/mod/elona/data/item.lua
+++ b/src/mod/elona/data/item.lua
@@ -228,6 +228,7 @@ local function open_new_years_gift(self, params)
 
    new_years_gift_effect(sep, params.chara)
    sep.params.chest_item_level = 0
+   sep:stack()
 
    return "turn_end"
    -- <<<<<<<< shade2/action.hsp:961 	} ..
@@ -14056,6 +14057,7 @@ local item =
          coefficient = 100,
 
          is_precious = true,
+         always_stack = true,
 
          tags = { "noshop" },
          rftags = { "ore" },

--- a/src/mod/elona/data/magic/unique.lua
+++ b/src/mod/elona/data/magic/unique.lua
@@ -192,7 +192,7 @@ local function do_curse(self, params)
    Gui.play_sound("base.curse3")
    local cb = Anim.load("elona.anim_curse", target.x, target.y)
    Gui.start_draw_callback(cb)
-   item:stack()
+   item:stack(true)
 
    return true
 end
@@ -521,7 +521,7 @@ data:add {
          Gui.mes("ui.inv.identify.need_more_power")
       end
 
-      item:stack()
+      item:stack(true)
 
       return true
    end
@@ -605,7 +605,7 @@ data:add {
          if chance > 0 and params.power >= chance then
             total_uncursed = total_uncursed + 1
             item.curse_state = Enum.CurseState.Normal
-            item:stack()
+            item:stack(true)
          else
             total_resisted = total_resisted + 1
          end

--- a/src/mod/elona/data/plant.lua
+++ b/src/mod/elona/data/plant.lua
@@ -23,7 +23,7 @@ local function generate_item(cb)
 
       local item = Itemgen.create(plant.x, plant.y, filter, params.chara)
       Gui.mes("action.plant.harvest", item:build_name())
-      item:stack()
+      item:stack(true)
    end
 end
 

--- a/src/test/lib/test_util.lua
+++ b/src/test/lib/test_util.lua
@@ -50,12 +50,12 @@ function test_util.stripped_chara(id, map, x, y)
    return chara
 end
 
-function test_util.stripped_item(id, map, x, y)
+function test_util.stripped_item(id, map, x, y, amount)
    local item
    if map == nil then
-      item = Item.create(id, x, y, {ownerless=true,amount=1})
+      item = Item.create(id, x, y, {ownerless=true,amount=amount or 1})
    else
-      item = Item.create(id, x, y, {amount=1}, map)
+      item = Item.create(id, x, y, {amount=amount or 1}, map)
    end
    item.curse_state = Enum.CurseState.Normal
    item.spoilage_date = nil

--- a/src/test/unit/api/IStackableObject.lua
+++ b/src/test/unit/api/IStackableObject.lua
@@ -2,9 +2,10 @@ local Item = require("api.Item")
 local Assert = require("api.test.Assert")
 local InstancedMap = require("api.InstancedMap")
 local Chara = require("api.Chara")
+local test_util = require("test.lib.test_util")
 
 function test_IStackableObject_separate__single()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=1,ownerless=true})
+   local item = test_util.stripped_item("elona.putitoro")
    Assert.eq(1, item.amount)
 
    local sep = item:separate()
@@ -14,7 +15,7 @@ function test_IStackableObject_separate__single()
 end
 
 function test_IStackableObject_separate__multiple()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
    Assert.eq(5, item.amount)
 
    local sep = item:separate()
@@ -26,7 +27,7 @@ function test_IStackableObject_separate__multiple()
 end
 
 function test_IStackableObject_separate__amount()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
    Assert.eq(5, item.amount)
 
    local sep = item:separate(3)
@@ -38,7 +39,7 @@ function test_IStackableObject_separate__amount()
 end
 
 function test_IStackableObject_separate__amount_exceeding()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
    Assert.eq(5, item.amount)
 
    local sep = item:separate(10)
@@ -47,52 +48,11 @@ function test_IStackableObject_separate__amount_exceeding()
    Assert.eq(sep, item)
 end
 
-function test_IStackableObject_can_stack_with__nonobject()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
-   Assert.eq(false, item:can_stack_with(1))
-   Assert.eq(false, item:can_stack_with({}))
-   Assert.eq(false, item:can_stack_with(function() end))
-end
-
-function test_IStackableObject_can_stack_with__self()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
-   Assert.eq(false, item:can_stack_with(item))
-end
-
-function test_IStackableObject_can_stack_with__different_object_type()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
-   local chara = Chara.create("elona.putit", nil, nil, {ownerless=true})
-   Assert.eq(false, item:can_stack_with(chara))
-end
-
-function test_IStackableObject_can_stack_with__no_location()
-   local map = InstancedMap:new(10, 10)
-   map:clear("elona.cobble")
-
-   local item_ownerless = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
-   local item_map = Item.create("elona.putitoro", 1, 1, {amount=5}, map)
-
-   Assert.eq(false, item_ownerless:can_stack_with(item_map))
-   Assert.eq(false, item_map:can_stack_with(item_ownerless))
-end
-
-function test_IStackableObject_can_stack_with__different_location()
-   local map = InstancedMap:new(10, 10)
-   map:clear("elona.cobble")
-
-   local item_ownerless = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
-   local chara = Chara.create("elona.putit", 1, 1, {}, map)
-   local item_chara = Item.create("elona.putitoro", nil, nil, {amount=5}, chara)
-
-   Assert.eq(false, item_ownerless:can_stack_with(item_chara))
-   Assert.eq(false, item_chara:can_stack_with(item_ownerless))
-end
-
 function test_IStackableObject_separate__same_location()
    local map = InstancedMap:new(10, 10)
    map:clear("elona.cobble")
 
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5}, map)
+   local item = test_util.stripped_item("elona.putitoro", map, 1, 1, 5)
    Assert.eq(5, item.amount)
    Assert.eq(map, item:get_location())
 
@@ -102,23 +62,121 @@ function test_IStackableObject_separate__same_location()
    Assert.eq(item:get_location(), sep:get_location())
 end
 
-disable("Bug #119")
+function test_IStackableObject_separate__events()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+
+   local sep = item:separate()
+   local result, id, name = item:compare_events(sep)
+
+   Assert.eq(true, result, ("%s:%s"):format(id, name))
+end
+
+function test_IStackableObject_can_stack_with__nonobject()
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+   Assert.eq(false, item:can_stack_with(1))
+   Assert.eq(false, item:can_stack_with({}))
+   Assert.eq(false, item:can_stack_with(function() end))
+end
+
+function test_IStackableObject_can_stack_with__self()
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+   Assert.eq(false, item:can_stack_with(item))
+end
+
+function test_IStackableObject_can_stack_with__different_object_type()
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+   local chara = Chara.create("elona.putit", nil, nil, {ownerless=true})
+   Assert.eq(false, item:can_stack_with(chara))
+end
+
+function test_IStackableObject_can_stack_with__no_location()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local item_ownerless = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+   local item_map = test_util.stripped_item("elona.putitoro", map, 1, 1, 5)
+
+   Assert.eq(false, item_ownerless:can_stack_with(item_map))
+   Assert.eq(false, item_map:can_stack_with(item_ownerless))
+end
+
+function test_IStackableObject_can_stack_with__different_location()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local item_ownerless = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
+   local chara = Chara.create("elona.putit", 1, 1, {}, map)
+   local item_chara = test_util.stripped_item("elona.putitoro", chara, nil, nil, 5)
+
+   Assert.eq(false, item_ownerless:can_stack_with(item_chara))
+   Assert.eq(false, item_chara:can_stack_with(item_ownerless))
+end
+
+function test_IStackableObject_can_stack_with__different_id()
+   local item_a = test_util.stripped_item("elona.putitoro")
+   local item_b = test_util.stripped_item("elona.apple")
+
+   Assert.eq(false, item_a:can_stack_with(item_b))
+   Assert.eq(false, item_b:can_stack_with(item_b))
+end
+
 function test_IStackableObject_can_stack_with__separated()
-   local item = Item.create("elona.putitoro", nil, nil, {amount=5,ownerless=true})
+   local item = test_util.stripped_item("elona.putitoro", nil, nil, nil, 5)
    local sep = item:separate(2)
 
    Assert.eq(true, item:can_stack_with(sep))
    Assert.eq(true, sep:can_stack_with(item))
 end
 
-disable("Bug #119")
 function test_IStackableObject_can_stack_with__separated_in_map()
    local map = InstancedMap:new(10, 10)
    map:clear("elona.cobble")
 
-   local item = Item.create("elona.putitoro", 1, 1, {amount=5}, map)
+   local item = test_util.stripped_item("elona.putitoro", map, 1, 1, 5)
    local sep = item:separate(2)
 
    Assert.eq(true, item:can_stack_with(sep))
    Assert.eq(true, sep:can_stack_with(item))
+end
+
+function test_IStackableObject_stack()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local item_a = test_util.stripped_item("elona.putitoro", map, 1, 1)
+   local item_b = test_util.stripped_item("elona.putitoro", map, 1, 2)
+   local item_c = test_util.stripped_item("elona.apple", map, 1, 3)
+   item_b:set_pos(1, 1)
+   item_c:set_pos(1, 1)
+
+   Assert.eq(1, item_a.amount)
+   Assert.eq(1, item_b.amount)
+   Assert.eq(1, item_c.amount)
+
+   item_b:stack()
+
+   Assert.eq(0, item_a.amount)
+   Assert.eq(2, item_b.amount)
+   Assert.eq(1, item_c.amount)
+
+   item_a:stack()
+
+   Assert.eq(0, item_a.amount)
+   Assert.eq(2, item_b.amount)
+   Assert.eq(1, item_c.amount)
+end
+
+function test_IStackableObject_stack__chara()
+   local chara = test_util.stripped_chara("elona.putit")
+
+   local item_a = test_util.stripped_item("elona.putitoro", chara)
+   local item_b = test_util.stripped_item("elona.putitoro", chara)
+   local item_c = test_util.stripped_item("elona.apple", chara)
+
+   Assert.eq(0, item_a.amount)
+   Assert.eq(2, item_b.amount)
+   Assert.eq(1, item_c.amount)
 end


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
--> 

Closes #119.

### Description
Fixes item stacking, and makes `ModExtTable` comparable for the meantime.