### PR TITLE
Make default HUD message window replaceable

### DIFF
--- a/src/api/Gui.lua
+++ b/src/api/Gui.lua
@@ -1,5 +1,4 @@
 --- @module Gui
-local MapObject = require("api.MapObject")
 
 local Env = require("api.Env")
 local I18N = require("api.I18N")
@@ -16,6 +15,8 @@ local data = require("internal.data")
 local field_renderer = require("internal.field_renderer")
 local InstancedMap = require("api.InstancedMap")
 local draw_layer_spec = require("internal.draw_layer_spec")
+local MapObject = require("api.MapObject")
+local Event = require("api.Event")
 
 local Gui = {}
 
@@ -387,9 +388,7 @@ function Gui.mes_c(text, color, ...)
          print(ansicolors(mes))
       end
    else
-      if field.is_active then
-         field:get_message_window():message(text, color_tbl)
-      end
+      Event.trigger("base.on_hud_message", {action="message",text=text,color=color_tbl})
    end
 end
 
@@ -457,7 +456,7 @@ end
 
 --- Clears the HUD message window.
 function Gui.mes_clear()
-   field:get_message_window():clear()
+   Event.trigger("base.on_hud_message", {action="clear"})
    capitalize = true
    newline = true
 end
@@ -465,7 +464,7 @@ end
 --- Starts a new line in the HUD message window.
 -- TODO: just use \n inline
 function Gui.mes_newline()
-   field:get_message_window():do_newline()
+   Event.trigger("base.on_hud_message", {action="newline"})
    newline = true
 end
 
@@ -474,7 +473,7 @@ function Gui.mes_continue_sentence()
 end
 
 function Gui.mes_duplicate()
-   field:get_message_window():prevent_next_duplicate()
+   Event.trigger("base.on_hud_message", {action="duplicate"})
 end
 
 function Gui.mes_halt()

--- a/src/api/gui/IUiWidget.lua
+++ b/src/api/gui/IUiWidget.lua
@@ -1,3 +1,4 @@
+local IEventEmitter = require("api.IEventEmitter")
 local IUiElement = require("api.gui.IUiElement")
 
 local IUiWidget = class.interface("IUiWidget",
@@ -5,9 +6,10 @@ local IUiWidget = class.interface("IUiWidget",
                                    default_widget_position = "function",
                                    default_widget_refresh = "function",
                                    default_widget_z_order = "function",
-                                   set_transparency = "function"
+                                   set_transparency = "function",
+                                   bind_events = "function"
                                 },
-                                IUiElement)
+                                {IUiElement, IEventEmitter})
 
 function IUiWidget:default_widget_position(x, y, width, height)
    return x, y, width, height
@@ -21,6 +23,9 @@ function IUiWidget:default_widget_z_order()
 end
 
 function IUiWidget:set_transparency(amount)
+end
+
+function IUiWidget:bind_events()
 end
 
 return IUiWidget

--- a/src/api/gui/WidgetContainer.lua
+++ b/src/api/gui/WidgetContainer.lua
@@ -3,6 +3,7 @@ local IUiElement = require("api.gui.IUiElement")
 local WidgetHolder = require("api.gui.WidgetHolder")
 local IUiWidget = require("api.gui.IUiWidget")
 local PriorityMap = require("api.PriorityMap")
+local IEventEmitter = require("api.IEventEmitter")
 
 local WidgetContainer = class.class("WidgetContainer", IUiElement)
 
@@ -40,6 +41,9 @@ function WidgetContainer:add(widget, tag, opts)
          error(("tag '%s' is already in use"):format(tag))
       end
    end
+
+   IEventEmitter.init(widget)
+   widget:bind_events()
 
    local holder = WidgetHolder:new(widget,
                                    tag,

--- a/src/api/gui/hud/MainHud.lua
+++ b/src/api/gui/hud/MainHud.lua
@@ -1,17 +1,6 @@
 local IHud = require("api.gui.hud.IHud")
 local IInput = require("api.gui.IInput")
 local InputHandler = require("api.gui.InputHandler")
-local UiBar = require("api.gui.hud.UiBar")
-local UiBuffs = require("api.gui.hud.UiBuffs")
-local UiClock = require("api.gui.hud.UiClock")
-local UiGoldPlatinum = require("api.gui.hud.UiGoldPlatinum")
-local UiLevel = require("api.gui.hud.UiLevel")
-local UiMessageWindow = require("api.gui.hud.UiMessageWindow")
-local UiMinimap = require("api.gui.hud.UiMinimap")
-local UiStatsBar = require("api.gui.hud.UiStatsBar")
-local UiStatusEffects = require("api.gui.hud.UiStatusEffects")
-local UiSkillTracker = require("api.gui.hud.UiSkillTracker")
-local UiAutoTurn = require("api.gui.hud.UiAutoTurn")
 local WidgetContainer = require("api.gui.WidgetContainer")
 
 local MainHud = class.class("MainHud", IHud)
@@ -21,36 +10,6 @@ function MainHud:init()
    self.input = InputHandler:new()
 
    self.widgets = WidgetContainer:new()
-
-   -- TODO to avoid circular dependencies, move all this into a
-   -- `base.on_engine_init` handler.
-   self.widgets:add(UiMessageWindow:new(), "hud_message_window")
-   self.widgets:add(UiStatusEffects:new(), "hud_status_effects")
-   self.widgets:add(UiClock:new(), "hud_clock")
-   self.widgets:add(UiSkillTracker:new(), "hud_skill_tracker")
-   self.widgets:add(UiGoldPlatinum:new(), "hud_gold_platinum")
-   self.widgets:add(UiLevel:new(), "hud_level")
-   self.widgets:add(UiStatsBar:new(), "hud_stats_bar")
-   self.widgets:add(UiMinimap:new(), "hud_minimap")
-   self.widgets:add(UiBuffs:new(), "hud_buffs")
-   self.widgets:add(UiAutoTurn:new(), "hud_auto_turn")
-
-   local position, refresh
-   position = function(self, x, y, width, height)
-      return math.floor((width - 84) / 2) - 100, height - (72 + 16) - 12
-   end
-   refresh = function(self, player)
-      self:set_data(player.hp, player:calc("max_hp"))
-   end
-   self.widgets:add(UiBar:new("hud_hp_bar", 0, 0, true), "hud_hp_bar", { position = position, refresh = refresh })
-
-   position = function(self, x, y, width, height)
-      return math.floor((width - 84) / 2) + 40, height - (72 + 16) - 12
-   end
-   refresh = function(self, player)
-      self:set_data(player.mp, player:calc("max_mp"))
-   end
-   self.widgets:add(UiBar:new("hud_mp_bar", 0, 0, true), "hud_mp_bar", { position = position, refresh = refresh })
 end
 
 function MainHud:default_z_order()

--- a/src/api/gui/hud/UiGoldPlatinum.lua
+++ b/src/api/gui/hud/UiGoldPlatinum.lua
@@ -28,18 +28,7 @@ function UiGoldPlatinum:relayout(x, y)
    self.t = UiTheme.load(self)
 end
 
-local Chara
-
 function UiGoldPlatinum:draw()
-   -- HACK hud
-   Chara = Chara or require("api.Chara")
-   local chara = Chara.player()
-   if not chara then
-      return
-   end
-   local gold = chara.gold
-   local plat = chara.platinum
-
    Draw.set_font(12)
 
    Draw.set_color(255, 255, 255)

--- a/src/api/gui/hud/UiMessageWindow.lua
+++ b/src/api/gui/hud/UiMessageWindow.lua
@@ -4,8 +4,9 @@ local IUiWidget = require("api.gui.IUiWidget")
 local CircularBuffer = require("api.CircularBuffer")
 local save = require("internal.global.save")
 local config = require("internal.config")
+local IEventEmitter = require("api.IEventEmitter")
 
-local UiMessageWindow = class.class("UiMessageWindow", IUiWidget)
+local UiMessageWindow = class.class("UiMessageWindow", {IUiWidget, IEventEmitter})
 
 function UiMessageWindow:init()
    self.width = 800
@@ -28,12 +29,32 @@ function UiMessageWindow:init()
    self:recalc_lines()
 end
 
+function UiMessageWindow:handle_on_hud_message(params)
+   local action = params.action
+
+   if action == "message" then
+      self:message(params.text, params.color)
+   elseif action == "newline" then
+      self:do_newline()
+   elseif action == "new_turn" then
+      self:new_turn()
+   elseif action == "clear" then
+      self:clear()
+   end
+end
+
 function UiMessageWindow:default_widget_position(x, y, width, height)
    return x + 124, height - (72 + 16), width - 124, 72
 end
 
 function UiMessageWindow:default_widget_z_order()
    return 50000
+end
+
+function UiMessageWindow:bind_events()
+   self:connect_global("base.on_hud_message",
+                       "Handle HUD message",
+                       function(_, params) self:handle_on_hud_message(params) end)
 end
 
 function UiMessageWindow:relayout(x, y, width, height)

--- a/src/api/gui/hud/UiSkillTracker.lua
+++ b/src/api/gui/hud/UiSkillTracker.lua
@@ -5,6 +5,8 @@ local UiTheme = require("api.gui.UiTheme")
 local I18N = require("api.I18N")
 local save = require("internal.global.save")
 local UiShadowedText = require("api.gui.UiShadowedText")
+local Map = require("api.Map")
+local Chara = require("api.Chara")
 
 local UiSkillTracker = class.class("UiSkillTracker", {IUiWidget, ISettable})
 
@@ -58,9 +60,6 @@ function UiSkillTracker:relayout(x, y)
    self.text_height = Draw.text_height()
 end
 
-local Chara
-local Map
-
 function UiSkillTracker:draw()
    -- >>>>>>>> shade2/screen.hsp:352 	ap3=0 ...
    local y = self.y
@@ -84,10 +83,6 @@ function UiSkillTracker:draw()
 end
 
 function UiSkillTracker:update()
-   -- HACK
-   Map = Map or require("api.Map")
-   Chara = Chara or require("api.Chara")
-
    local remove = {}
    for uid, _ in pairs(self.tracked_skill_ids) do
       local chara = Map.current():get_object(uid)

--- a/src/game/field_layer.lua
+++ b/src/game/field_layer.lua
@@ -220,10 +220,6 @@ function field_layer:refresh_hud(relayout)
    end
 end
 
-function field_layer:get_message_window()
-   return self.hud.widgets:get("hud_message_window"):widget()
-end
-
 function field_layer:update(dt, ran_action, result)
    self.renderer:update(self.map, dt)
 

--- a/src/game/field_logic.lua
+++ b/src/game/field_logic.lua
@@ -184,7 +184,7 @@ function field_logic.turn_begin()
    -- BUG: don't pass time if just loaded from save
    World.pass_time_in_seconds(starting_turn_time / 5 + 1)
 
-   field:get_message_window():new_turn()
+   Event.trigger("base.on_hud_message", {action="new_turn"})
 
    return "pass_turns"
 end

--- a/src/game/startup.lua
+++ b/src/game/startup.lua
@@ -150,6 +150,9 @@ function startup.run(mods)
    draw.reload_window_mode()
    draw.set_default_font(config.base.default_font)
 
+   -- Load built-in event hooks.
+   events.require_all()
+
    Event.trigger("base.before_engine_init")
 
    progress("Loading tilemaps...")
@@ -161,9 +164,6 @@ function startup.run(mods)
    i18n.switch_language(config.base.language)
 
    field:setup_repl()
-
-   -- Load built-in event hooks.
-   events.require_all()
 
    Event.trigger("base.on_engine_init")
 

--- a/src/internal/data/events.lua
+++ b/src/internal/data/events.lua
@@ -141,5 +141,6 @@ data:add_multi(
       { _id = "on_object_prototype_changed" },
       { _id = "on_chara_calc_can_recruit_allies" },
       { _id = "on_map_generated_from_archetype" },
+      { _id = "on_hud_message" },
    }
 )

--- a/src/internal/events/init.lua
+++ b/src/internal/events/init.lua
@@ -15,6 +15,7 @@ function events.require_all()
    require("internal.events.debug")
    require("internal.events.map_delete")
    require("internal.events.item")
+   require("internal.events.widget")
 end
 
 return events

--- a/src/internal/events/widget.lua
+++ b/src/internal/events/widget.lua
@@ -1,0 +1,46 @@
+local Gui = require("api.Gui")
+local Event = require("api.Event")
+local UiBar = require("api.gui.hud.UiBar")
+local UiBuffs = require("api.gui.hud.UiBuffs")
+local UiClock = require("api.gui.hud.UiClock")
+local UiGoldPlatinum = require("api.gui.hud.UiGoldPlatinum")
+local UiLevel = require("api.gui.hud.UiLevel")
+local UiMessageWindow = require("api.gui.hud.UiMessageWindow")
+local UiMinimap = require("api.gui.hud.UiMinimap")
+local UiStatsBar = require("api.gui.hud.UiStatsBar")
+local UiStatusEffects = require("api.gui.hud.UiStatusEffects")
+local UiSkillTracker = require("api.gui.hud.UiSkillTracker")
+local UiAutoTurn = require("api.gui.hud.UiAutoTurn")
+
+local function add_default_widgets()
+   -- TODO to avoid circular dependencies, move all this into a
+   -- `base.on_engine_init` handler.
+   Gui.add_hud_widget(UiMessageWindow:new(), "hud_message_window")
+   Gui.add_hud_widget(UiStatusEffects:new(), "hud_status_effects")
+   Gui.add_hud_widget(UiClock:new(), "hud_clock")
+   Gui.add_hud_widget(UiSkillTracker:new(), "hud_skill_tracker")
+   Gui.add_hud_widget(UiGoldPlatinum:new(), "hud_gold_platinum")
+   Gui.add_hud_widget(UiLevel:new(), "hud_level")
+   Gui.add_hud_widget(UiStatsBar:new(), "hud_stats_bar")
+   Gui.add_hud_widget(UiMinimap:new(), "hud_minimap")
+   Gui.add_hud_widget(UiBuffs:new(), "hud_buffs")
+   Gui.add_hud_widget(UiAutoTurn:new(), "hud_auto_turn")
+
+   local position, refresh
+   position = function(self, x, y, width, height)
+      return math.floor((width - 84) / 2) - 100, height - (72 + 16) - 12
+   end
+   refresh = function(self, player)
+      self:set_data(player.hp, player:calc("max_hp"))
+   end
+   Gui.add_hud_widget(UiBar:new("hud_hp_bar", 0, 0, true), "hud_hp_bar", { position = position, refresh = refresh })
+
+   position = function(self, x, y, width, height)
+      return math.floor((width - 84) / 2) + 40, height - (72 + 16) - 12
+   end
+   refresh = function(self, player)
+      self:set_data(player.mp, player:calc("max_mp"))
+   end
+   Gui.add_hud_widget(UiBar:new("hud_mp_bar", 0, 0, true), "hud_mp_bar", { position = position, refresh = refresh })
+end
+Event.register("base.before_engine_init", "Add default_widgets", add_default_widgets, {priority = 10000})

--- a/src/mod/skill_tracker_ex/api/gui/UiSkillTrackerEx.lua
+++ b/src/mod/skill_tracker_ex/api/gui/UiSkillTrackerEx.lua
@@ -7,6 +7,8 @@ local Ui = require("api.Ui")
 local ColorBand = require("mod.skill_tracker_ex.api.gui.ColorBand")
 local LogWidget = require("mod.tools.api.gui.LogWidget")
 local UiShadowedText = require("api.gui.UiShadowedText")
+local Map = require("api.Map")
+local Chara = require("api.Chara")
 
 local UiSkillTrackerEx = class.class("UiSkillTrackerEx", {IUiWidget, ISettable})
 
@@ -108,9 +110,6 @@ function UiSkillTrackerEx:on_gain_skill_exp(skill_id, base_amount, actual_amount
    self.log_widget:print_raw(("%s    %s%d (%d)"):format(skill_name, sign, base_amount, actual_amount), color)
 end
 
-local Chara
-local Map
-
 function UiSkillTrackerEx:draw()
    local y = self.y
 
@@ -139,10 +138,6 @@ function UiSkillTrackerEx:draw()
 end
 
 function UiSkillTrackerEx:update(dt)
-   -- HACK
-   Map = Map or require("api.Map")
-   Chara = Chara or require("api.Chara")
-
    local remove = {}
    for uid, _ in pairs(self.tracked_skill_ids) do
       local chara = Map.current():get_object(uid)


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [x] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

Closes #222.

### Description
Makes the message window moddable putting an event between `Gui.mes_c()` and the message window. Now any widget that subscribes to the message event can receive messages.

Also, all widgets implement `IEventEmitter` now.