### PR TITLE
Implement aspects

### DIFF
--- a/src/api/Aspect.lua
+++ b/src/api/Aspect.lua
@@ -1,0 +1,38 @@
+local env = require("internal.env")
+local IAspect = require("api.IAspect")
+local aspect_state = require("internal.global.aspect_state")
+
+local Aspect = {}
+
+function Aspect.get_default_impl(iface)
+   if type(iface) == "string" then
+      iface = env.safe_require(iface)
+   end
+   class.assert_is_an(IAspect, iface)
+   assert(class.is_interface(iface))
+
+   local impl = aspect_state.default_impls[iface.__name]
+   if impl == nil and iface.default_impl then
+      Aspect.set_default_impl(iface, iface.default_impl)
+   end
+
+   return aspect_state.default_impls[iface.__name] or nil
+end
+
+function Aspect.set_default_impl(iface, impl)
+   if type(iface) == "string" then
+      iface = env.safe_require(iface)
+   end
+   class.assert_is_an(IAspect, iface)
+   assert(class.is_interface(iface))
+
+   if type(impl) == "string" then
+      impl = env.safe_require(impl)
+   end
+   class.assert_is_an(IAspect, impl)
+   assert(class.is_class(impl))
+
+   aspect_state.default_impls[iface.__name] = impl
+end
+
+return Aspect

--- a/src/api/AspectHolder.lua
+++ b/src/api/AspectHolder.lua
@@ -1,0 +1,58 @@
+local env = require("internal.env")
+local IAspect = require("api.IAspect")
+local PriorityMap = require("api.PriorityMap")
+local Aspect = require("api.Aspect")
+
+local AspectHolder = class.class("AspectHolder")
+
+AspectHolder.DEFAULT_PRIORITY = 100000
+
+function AspectHolder:init()
+   self._store = PriorityMap:new()
+end
+
+function AspectHolder:iter()
+   return self._store:iter()
+end
+
+function AspectHolder:get_aspect(target, iface)
+   if type(iface) == "string" then
+      iface = env.safe_require(iface)
+   end
+   class.assert_is_an(IAspect, iface)
+
+   local name = assert(iface.__name)
+   return self._store:get(name)
+end
+
+function AspectHolder:get_aspect_or_default(target, iface, ...)
+   if type(iface) == "string" then
+      iface = env.safe_require(iface)
+   end
+   class.assert_is_an(IAspect, iface)
+
+   local name = assert(iface.__name)
+   local aspect = self._store:get(name)
+
+   if aspect == nil then
+      local default = Aspect.get_default_impl(iface)
+      aspect = default:new(target, ...)
+      local priority = AspectHolder.DEFAULT_PRIORITY
+      self._store:set(name, aspect, priority)
+   end
+
+   return aspect
+end
+
+function AspectHolder:set_aspect(target, iface, aspect, priority)
+   if type(iface) == "string" then
+      iface = env.safe_require(iface)
+   end
+   class.assert_is_an(IAspect, iface)
+   class.assert_is_an(iface, aspect)
+
+   local name = assert(iface.__name)
+   self._store:set(name, aspect, priority or AspectHolder.DEFAULT_PRIORITY)
+end
+
+return AspectHolder

--- a/src/api/AspectHolder.lua
+++ b/src/api/AspectHolder.lua
@@ -2,8 +2,9 @@ local env = require("internal.env")
 local IAspect = require("api.IAspect")
 local PriorityMap = require("api.PriorityMap")
 local Aspect = require("api.Aspect")
+local IComparable = require("api.IComparable")
 
-local AspectHolder = class.class("AspectHolder")
+local AspectHolder = class.class("AspectHolder", IComparable)
 
 AspectHolder.DEFAULT_PRIORITY = 100000
 
@@ -51,8 +52,74 @@ function AspectHolder:set_aspect(target, iface, aspect, priority)
    class.assert_is_an(IAspect, iface)
    class.assert_is_an(iface, aspect)
 
+   aspect.temp = aspect.temp or {}
+
    local name = assert(iface.__name)
    self._store:set(name, aspect, priority or AspectHolder.DEFAULT_PRIORITY)
+end
+
+local function find_iface(aspect, name)
+   return fun.iter(aspect.__interfaces):filter(function(i) return i.__name == name end):nth(1)
+end
+
+function AspectHolder:compare(other)
+   local seen = table.set {}
+
+   for _, aspect, name in self:iter() do
+      seen[name] = true
+      local other_aspect = other._store:get(name)
+      if other_aspect == nil then
+         return false
+      end
+
+      if aspect.__class ~= other_aspect.__class then
+         return false
+      end
+
+      if class.is_an(IComparable, aspect) then
+         if not aspect:compare(other_aspect) then
+            return false
+         end
+      else
+         -- Compare the values of the interface requirements of the two aspects.
+         local iface = find_iface(aspect, name)
+         if iface == nil then
+            return false
+         end
+
+         local reqs = table.deepcopy(iface.reqs) or {}
+         reqs["temp"] = "table"
+
+         for key, req in pairs(reqs) do
+            local our_value = aspect[key]
+            local their_value = other_aspect[key]
+
+            if class.is_an(IComparable, our_value) then
+               if not our_value:compare(their_value) then
+                  return false
+               end
+            else
+               if (type(our_value) == "table" and type(their_value) == "table") then
+                  if not table.deepcompare(our_value, their_value) then
+                     return false
+                  end
+               else
+                  if our_value ~= their_value then
+                     return false
+                  end
+               end
+            end
+         end
+      end
+   end
+
+   for _, _, name in other:iter() do
+      if not seen[name] then
+         return false
+      end
+   end
+
+   return true
 end
 
 return AspectHolder

--- a/src/api/Doc.lua
+++ b/src/api/Doc.lua
@@ -313,7 +313,6 @@ end
 
 function Doc.on_hotload(old, new)
    table.replace_with(old, new)
-   rawset(_G, "help", Doc.help)
    local field = require("game.field")
    if field.repl then
       field.repl.env.help = Doc.help

--- a/src/api/IAspect.lua
+++ b/src/api/IAspect.lua
@@ -1,3 +1,5 @@
-local IAspect = class.interface("IAspect")
+local IAspectModdable = require("api.IAspectModdable")
+
+local IAspect = class.interface("IAspect", {}, { IAspectModdable })
 
 return IAspect

--- a/src/api/IAspect.lua
+++ b/src/api/IAspect.lua
@@ -1,0 +1,3 @@
+local IAspect = class.interface("IAspect")
+
+return IAspect

--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -1,0 +1,55 @@
+local AspectHolder = require("api.AspectHolder")
+local IAspect = require("api.IAspect")
+local Aspect = require("api.Aspect")
+
+local IAspectHolder = class.interface("IAspectHolder")
+
+function IAspectHolder:init()
+   self._aspects = AspectHolder:new()
+end
+
+local function is_aspect(v)
+   return class.is_interface(v) and class.is_an(IAspect, v)
+end
+
+local function default_aspect(obj, iface, params)
+   local default = Aspect.get_default_impl(iface)
+   local aspect = default:new(obj, params)
+   obj:set_aspect(iface, aspect)
+end
+
+function IAspectHolder:normal_build(params)
+   local ext = self.proto.ext
+   if ext then
+      for k, v in pairs(ext) do
+         print("Is aspect",k,v,is_aspect(k),is_aspect(v))
+         if type(k) == "number" and is_aspect(v) then
+            default_aspect(self, v, params)
+         elseif is_aspect(k) then
+            local _params = params
+            if type(v) == "table" then
+               _params = table.merge_ex(table.deepcopy(v), params)
+            end
+            default_aspect(self, k, _params)
+         end
+      end
+   end
+end
+
+function IAspectHolder:get_aspect(iface)
+   return self._aspects:get_aspect(self, iface)
+end
+
+function IAspectHolder:get_aspect_or_default(iface, ...)
+   return self._aspects:get_aspect_or_default(self, iface, ...)
+end
+
+function IAspectHolder:set_aspect(iface, aspect)
+   self._aspects:set_aspect(self, iface, aspect)
+end
+
+function IAspectHolder:iter_aspects()
+   return fun.wrap(self._aspects:iter())
+end
+
+return IAspectHolder

--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -1,6 +1,7 @@
 local AspectHolder = require("api.AspectHolder")
 local IAspect = require("api.IAspect")
 local Aspect = require("api.Aspect")
+local IAspectModdable = require("api.IAspectModdable")
 
 local IAspectHolder = class.interface("IAspectHolder")
 
@@ -15,6 +16,7 @@ end
 local function default_aspect(obj, iface, params)
    local default = Aspect.get_default_impl(iface)
    local aspect = default:new(obj, params)
+   IAspectModdable.init(aspect)
    obj:set_aspect(iface, aspect)
 end
 
@@ -36,6 +38,12 @@ function IAspectHolder:normal_build(params)
    end
 end
 
+function IAspectHolder:on_refresh()
+   for _, aspect in self:iter_aspects() do
+      IAspectModdable.on_refresh(aspect)
+   end
+end
+
 function IAspectHolder:get_aspect(iface)
    return self._aspects:get_aspect(self, iface)
 end
@@ -48,8 +56,36 @@ function IAspectHolder:set_aspect(iface, aspect)
    self._aspects:set_aspect(self, iface, aspect)
 end
 
-function IAspectHolder:iter_aspects()
+function IAspectHolder:iter_aspects(iface)
+   if iface then
+      return self:iter_aspects():filter(function(a) return class.is_an(iface, a) end)
+   end
+
    return fun.wrap(self._aspects:iter())
+end
+
+function IAspectHolder:calc_aspect(iface, prop)
+   local aspect = self:get_aspect(self, iface)
+   if aspect == nil then
+      return nil
+   end
+   return aspect:calc(self, prop)
+end
+
+function IAspectHolder:mod_aspect(iface, prop, v, method, params)
+   local aspect = self:get_aspect(self, iface)
+   if aspect == nil then
+      error("Aspect is nil")
+   end
+   return aspect:mod(self, prop, v, method, params)
+end
+
+function IAspectHolder:mod_aspect_base(iface, prop, v, method, params)
+   local aspect = self:get_aspect(self, iface)
+   if aspect == nil then
+      error("Aspect is nil")
+   end
+   return aspect:mod_base(self, prop, v, method, params)
 end
 
 return IAspectHolder

--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -21,9 +21,9 @@ local function default_aspect(obj, iface, params)
 end
 
 function IAspectHolder:normal_build(params)
-   local ext = self.proto.ext
-   if ext then
-      for k, v in pairs(ext) do
+   local _ext = self.proto._ext
+   if _ext then
+      for k, v in pairs(_ext) do
          if type(k) == "number" and is_aspect(v) then
             default_aspect(self, v, params)
          elseif is_aspect(k) then

--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -24,7 +24,6 @@ function IAspectHolder:normal_build(params)
    local ext = self.proto.ext
    if ext then
       for k, v in pairs(ext) do
-         print("Is aspect",k,v,is_aspect(k),is_aspect(v))
          if type(k) == "number" and is_aspect(v) then
             default_aspect(self, v, params)
          elseif is_aspect(k) then
@@ -65,7 +64,7 @@ function IAspectHolder:iter_aspects(iface)
 end
 
 function IAspectHolder:calc_aspect(iface, prop)
-   local aspect = self:get_aspect(self, iface)
+   local aspect = self:get_aspect(iface)
    if aspect == nil then
       return nil
    end
@@ -73,7 +72,7 @@ function IAspectHolder:calc_aspect(iface, prop)
 end
 
 function IAspectHolder:mod_aspect(iface, prop, v, method, params)
-   local aspect = self:get_aspect(self, iface)
+   local aspect = self:get_aspect(iface)
    if aspect == nil then
       error("Aspect is nil")
    end
@@ -81,7 +80,7 @@ function IAspectHolder:mod_aspect(iface, prop, v, method, params)
 end
 
 function IAspectHolder:mod_aspect_base(iface, prop, v, method, params)
-   local aspect = self:get_aspect(self, iface)
+   local aspect = self:get_aspect(iface)
    if aspect == nil then
       error("Aspect is nil")
    end

--- a/src/api/IAspectModdable.lua
+++ b/src/api/IAspectModdable.lua
@@ -1,0 +1,44 @@
+local IAspectModdable = class.interface("IAspectModdable", {
+                                           -- on_refresh = "function",
+                                           -- calc = "function",
+                                           -- mod = "function",
+                                           -- mod_base = "function"
+                                                           })
+
+function IAspectModdable:init()
+   self.temp = {}
+end
+
+function IAspectModdable:on_refresh()
+   self.temp = {}
+end
+
+function IAspectModdable:calc(target, key)
+   self.temp = self.temp or {}
+
+   if self.temp[key] ~= nil then
+      return self.temp[key]
+   end
+
+   return self[key]
+end
+
+function IAspectModdable:mod(target, prop, v, method, params)
+   local defaults = self
+   if params and params.no_default then
+      defaults = nil
+   end
+   table.merge_ex_single(self.temp, v, method or "add", defaults, prop)
+   return self.temp[prop]
+end
+
+function IAspectModdable:mod_base(target, prop, v, method, params)
+   local defaults = self.proto
+   if params and params.no_default then
+      defaults = nil
+   end
+   table.merge_ex_single(self, v, method or "add", defaults, prop)
+   return self[prop]
+end
+
+return IAspectModdable

--- a/src/api/IMapObject.lua
+++ b/src/api/IMapObject.lua
@@ -40,6 +40,7 @@ end
 
 --- Refreshes this map object.
 function IMapObject:on_refresh()
+   IObject.on_refresh(self)
    self:refresh_cell_on_map()
 end
 

--- a/src/api/IModdable.lua
+++ b/src/api/IModdable.lua
@@ -11,12 +11,12 @@ function IModdable:on_refresh()
    self.temp = {}
 end
 
---- Obtains a property or calls a function to compute something. Using
---- this function instead of plain access (obj.prop) means the
---- property will support the value refresh system.
+--- Obtains a property to compute something. Using this function instead of
+--- plain access (obj.prop) means the property will support the value refresh
+--- system.
 --- @tparam string key
 --- @param ...
-function IModdable:calc(key, ...)
+function IModdable:calc(key)
    if self.temp[key] ~= nil then
       return self.temp[key]
    end

--- a/src/api/IObject.lua
+++ b/src/api/IObject.lua
@@ -3,6 +3,7 @@
 local IEventEmitter = require("api.IEventEmitter")
 local IModDataHolder = require("api.IModDataHolder")
 local IModdable = require("api.IModdable")
+local IAspectHolder = require("api.IAspectHolder")
 local data = require("internal.data")
 
 -- An object instance backed by a data prototype.
@@ -17,13 +18,14 @@ local IObject = class.interface("IObject",
                              refresh = "function",
                              finalize = "function",
                           },
-                          { IModdable, IModDataHolder }
+                          { IModdable, IModDataHolder, IAspectHolder }
 )
 
 function IObject:pre_build()
 end
 
-function IObject:normal_build()
+function IObject:normal_build(build_params)
+   IAspectHolder.normal_build(self, build_params)
 end
 
 function IObject:build()
@@ -37,6 +39,7 @@ end
 function IObject:init()
    IModdable.init(self)
    IModDataHolder.init(self)
+   IAspectHolder.init(self)
 end
 
 function IObject:on_refresh()

--- a/src/api/IObject.lua
+++ b/src/api/IObject.lua
@@ -44,6 +44,7 @@ end
 
 function IObject:on_refresh()
    IModdable.on_refresh(self)
+   IAspectHolder.on_refresh(self)
 end
 
 function IObject:finalize(build_params)

--- a/src/api/MapObject.lua
+++ b/src/api/MapObject.lua
@@ -121,7 +121,7 @@ end
 local function cycle_aware_copy(t, uids, cache, uid_mapping, first, opts)
    if type(t) ~= 'table' then return t end
    if cache[t] then return cache[t] end
-   if class.is_class_or_interface(t) then
+   if class.is_class(t) or class.is_interface(t) then
       cache[t] = t
       return t
    end
@@ -158,7 +158,7 @@ local function cycle_aware_copy(t, uids, cache, uid_mapping, first, opts)
          end
       end
    end
-   if t.__class and class.is_class_or_interface(mt) then
+   if t.__class and (class.is_class(mt) or class.is_interface(mt)) then
       res.__class = mt
    end
    if mt then

--- a/src/api/Object.lua
+++ b/src/api/Object.lua
@@ -92,7 +92,7 @@ function Object.finalize(obj, params)
    params = params or {}
 
    if not params.no_build then
-      obj:normal_build()
+      obj:normal_build(params.build_params)
       obj:finalize(params.build_params)
       obj:instantiate(true) -- events are bound by :finalize()
    end

--- a/src/api/Object.lua
+++ b/src/api/Object.lua
@@ -5,6 +5,10 @@ local IObject = require("api.IObject")
 
 local Object = {}
 
+local NO_SAVE_FIELDS = table.set {
+   "_ext"
+}
+
 -- Modification of penlight's algorithm to ignore class fields
 local function cycle_aware_copy(t, cache)
    -- TODO: standardize no-save fields
@@ -19,9 +23,11 @@ local function cycle_aware_copy(t, cache)
    local mt = getmetatable(t)
    for k,v in pairs(t) do
       -- TODO: standardize no-save fields
-      k = cycle_aware_copy(k, cache)
-      v = cycle_aware_copy(v, cache)
-      res[k] = v
+      if not NO_SAVE_FIELDS[k] then
+         k = cycle_aware_copy(k, cache)
+         v = cycle_aware_copy(v, cache)
+         res[k] = v
+      end
    end
    setmetatable(res,mt)
    return res

--- a/src/api/chara/IChara.lua
+++ b/src/api/chara/IChara.lua
@@ -31,6 +31,7 @@ local IEventEmitter = require("api.IEventEmitter")
 local save = require("internal.global.save")
 local PriorityMap = require("api.PriorityMap")
 local CharaMake = require("api.CharaMake")
+local IObject = require("api.IObject")
 
 -- TODO: move out of api
 local IChara = class.interface("IChara",
@@ -98,8 +99,10 @@ end
 --- the parameters to Chara.create(), but it becomes the caller's
 --- responsibility to ensure that IChara:build() is also called at
 --- some later point.
-function IChara:normal_build()
+function IChara:normal_build(params)
    self:emit("base.on_chara_normal_build")
+
+   IObject.normal_build(self, params)
 end
 
 --- Finishes initializing this character. All characters must run this

--- a/src/api/chara/IChara.lua
+++ b/src/api/chara/IChara.lua
@@ -147,7 +147,6 @@ end
 ---
 --- @overrides IMapObject.refresh
 function IChara:refresh()
-   IModdable.on_refresh(self)
    IMapObject.on_refresh(self)
    ICharaEquip.on_refresh(self)
    ICharaSkills.on_refresh(self)

--- a/src/api/chara/IChara.lua
+++ b/src/api/chara/IChara.lua
@@ -32,6 +32,7 @@ local save = require("internal.global.save")
 local PriorityMap = require("api.PriorityMap")
 local CharaMake = require("api.CharaMake")
 local IObject = require("api.IObject")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 -- TODO: move out of api
 local IChara = class.interface("IChara",
@@ -263,17 +264,19 @@ function IChara:produce_locale_data()
 end
 
 function IChara:refresh_weight()
+   -- >>>>>>>> shade2/item_func.hsp:288 #defcfunc inv_weight int a ...
    local weight = 0
    local cargo_weight = 0
    for _, i in self:iter_items() do
-      weight = weight + i:calc("weight")
-      cargo_weight = cargo_weight + i:calc("cargo_weight")
+      weight = weight + i:calc("weight") * i.amount
+      cargo_weight = cargo_weight + (i:calc_aspect(IItemCargo, "cargo_weight") or 0) * i.amount
    end
    self:reset("inventory_weight", weight)
    self:reset("cargo_weight", cargo_weight)
    self.max_inventory_weight = 45000
    self.inventory_weight_type = Enum.Burden.None
    self:emit("base.on_refresh_weight")
+   -- <<<<<<<< shade2/item_func.hsp:299 	return p ..
 end
 
 --- Sets this character's position. Use this function instead of updating x and y manually.

--- a/src/api/feat/IFeat.lua
+++ b/src/api/feat/IFeat.lua
@@ -28,7 +28,6 @@ end
 
 function IFeat:refresh()
    IMapObject.on_refresh(self)
-   IModdable.on_refresh(self)
    self:emit("elona_sys.on_feat_refresh") -- TODO move or rename
 end
 

--- a/src/api/feat/IFeat.lua
+++ b/src/api/feat/IFeat.lua
@@ -1,6 +1,7 @@
 local IEventEmitter = require("api.IEventEmitter")
 local IMapObject = require("api.IMapObject")
 local IModdable = require("api.IModdable")
+local IObject = require("api.IObject")
 
 -- A feat is anything that is a part of the map with a position. Feats
 -- also include traps.
@@ -12,7 +13,8 @@ function IFeat:pre_build()
    IEventEmitter.init(self)
 end
 
-function IFeat:normal_build()
+function IFeat:normal_build(params)
+   IObject.normal_build(self, params)
 end
 
 function IFeat:build()

--- a/src/api/gui/menu/InventoryMenu.lua
+++ b/src/api/gui/menu/InventoryMenu.lua
@@ -8,6 +8,7 @@ local MapObjectBatch = require("api.draw.MapObjectBatch")
 local save = require("internal.global.save")
 local config = require("internal.config")
 local Shortcut = require("mod.elona.api.Shortcut")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local IInput = require("api.gui.IInput")
 local UiList = require("api.gui.UiList")
@@ -180,7 +181,7 @@ function InventoryMenu:assign_shortcut(index)
       return
    end
 
-   if (item:calc("cargo_weight") or 0) > 0 then
+   if item:get_aspect(IItemCargo) then
       Gui.play_sound("base.fail1")
       Gui.mes("ui.inv.common.shortcut.cargo")
       return
@@ -253,7 +254,11 @@ function InventoryMenu.filter_item(ctxt, item)
 end
 
 local function default_detail_text(item)
-   return Ui.display_weight(item:calc("weight") * item.amount)
+   local weight = item:calc("weight")
+   if item:get_aspect(IItemCargo) then
+      weight = item:calc_aspect(IItemCargo, "cargo_weight")
+   end
+   return Ui.display_weight(weight * item.amount)
 end
 
 function InventoryMenu.build_list(ctxt)

--- a/src/api/item/IItem.lua
+++ b/src/api/item/IItem.lua
@@ -82,7 +82,6 @@ local function is_ammo(item)
 end
 
 function IItem:refresh()
-   IModdable.on_refresh(self)
    IMapObject.on_refresh(self)
    IItemEnchantments.on_refresh(self)
 

--- a/src/api/item/IItem.lua
+++ b/src/api/item/IItem.lua
@@ -33,12 +33,14 @@ function IItem:pre_build()
    IItemContainer.init(self)
 end
 
-function IItem:normal_build()
+function IItem:normal_build(params)
    self.name = self._id
    self.image = self.image or self.proto.image
 
    local fallbacks = data.fallbacks["base.item"]
    self:mod_base_with(table.deepcopy(fallbacks), "merge")
+
+   IObject.normal_build(self, params)
 end
 
 function IItem:build(params)

--- a/src/api/mef/IMef.lua
+++ b/src/api/mef/IMef.lua
@@ -29,7 +29,6 @@ end
 
 function IMef:refresh()
    IMapObject.on_refresh(self)
-   IModdable.on_refresh(self)
    if self.on_refresh then
       self:on_refresh()
    end

--- a/src/api/mef/IMef.lua
+++ b/src/api/mef/IMef.lua
@@ -2,6 +2,7 @@ local IEventEmitter = require("api.IEventEmitter")
 local IMapObject = require("api.IMapObject")
 local IModdable = require("api.IModdable")
 local Mef = require("api.Mef")
+local IObject = require("api.IObject")
 
 -- A mef, short for map effect, is an obstacle that can occupy a tile. There can
 -- only be a single mef on a tile at a time.
@@ -13,7 +14,8 @@ function IMef:pre_build()
    IEventEmitter.init(self)
 end
 
-function IMef:normal_build()
+function IMef:normal_build(params)
+   IObject.normal_build(self, params)
 end
 
 function IMef:build()

--- a/src/game/startup.lua
+++ b/src/game/startup.lua
@@ -107,7 +107,6 @@ function startup.run(mods)
    progress("Loading early modules...")
 
    -- Wrap these functions to allow hotloading via table access.
-   rawset(_G, "help", function(...) return Doc.help(...) end)
    rawset(_G, "pause", function(...) return Repl.pause(...) end)
 
    draw.add_global_widget(UiFpsCounter:new(), "fps_counter")

--- a/src/internal/data/schemas.lua
+++ b/src/internal/data/schemas.lua
@@ -706,8 +706,6 @@ If false, this item cannot be wished for.
          value = 1,
          params = {},
 
-         cargo_weight = 0,
-
          spoilage_date = nil,
 
          is_melee_weapon = nil,

--- a/src/internal/global/aspect_state.lua
+++ b/src/internal/global/aspect_state.lua
@@ -1,0 +1,3 @@
+return {
+   default_impls = {}
+}

--- a/src/mod/elona/api/Calc.lua
+++ b/src/mod/elona/api/Calc.lua
@@ -9,6 +9,7 @@ local Rank = require("mod.elona.api.Rank")
 local Filters = require("mod.elona.api.Filters")
 local Itemgen = require("mod.elona.api.Itemgen")
 local Item = require("api.Item")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local Calc = {}
 
@@ -164,8 +165,7 @@ function Calc.calc_item_value(item, mode, is_shop)
       value = value + math.clamp(fame / 40 + value * (fame / 80) / 100, 0, 800)
    end
 
-   local cargo_weight = item:calc("cargo_weight") or 0
-   if cargo_weight > 0 and is_shop and item:has_category("elona.cargo") then
+   if item:get_aspect(IItemCargo) and is_shop then
       -- TODO cargo rate fluctuation
       local trade_rate = 1
       value = value * trade_rate / 100
@@ -327,7 +327,7 @@ function Calc.will_chara_take_item(target, item, amount)
       end
    end
 
-   if item:calc("cargo_weight") > 0 then
+   if item:get_aspect(IItemCargo) then
       return false, "ui.inv.give.refuse_dialog.is_cargo"
    end
 

--- a/src/mod/elona/api/ElonaBuilding.lua
+++ b/src/mod/elona/api/ElonaBuilding.lua
@@ -15,6 +15,7 @@ local Chara = require("api.Chara")
 local Charagen = require("mod.elona.api.Charagen")
 local Building = require("mod.elona.api.Building")
 local Inventory = require("api.Inventory")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local ElonaBuilding = {}
 
@@ -59,7 +60,7 @@ function ElonaBuilding.is_item_sellable_in_shop(item)
       return false
    end
 
-   if item:calc("cargo_weight") > 0 or item:calc("quality") >= Enum.Quality.Unique or item:calc("value") < 50 then
+   if item:get_aspect(IItemCargo) or item:calc("quality") >= Enum.Quality.Unique or item:calc("value") < 50 then
       return false
    end
 

--- a/src/mod/elona/api/Itemname.lua
+++ b/src/mod/elona/api/Itemname.lua
@@ -17,6 +17,7 @@ local ElonaItem = require("mod.elona.api.ElonaItem")
 local Ui = require("api.Ui")
 local World = require("api.World")
 local Hunger = require("mod.elona.api.Hunger")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local Itemname = {}
 
@@ -455,7 +456,7 @@ function itemname.en(item, amount, no_article)
       end
 
       if identify > IdentifyState.None and s2 == "" then
-         if (item:calc("cargo_weight") or 0) > 0 then
+         if item:get_aspect(IItemCargo) then
             s2 = "cargo"
          end
          if item:has_category("elona.equip_wrist") or item:has_category("elona.equip_leg") then

--- a/src/mod/elona/api/aspect/IItemCargo.lua
+++ b/src/mod/elona/api/aspect/IItemCargo.lua
@@ -1,0 +1,7 @@
+local IAspect = require("api.IAspect")
+
+local IItemCargo = class.interface("IItemCargo", { cargo_weight = "number", cargo_quality = "number" }, { IAspect })
+
+IItemCargo.default_impl = "mod.elona.api.aspect.ItemCargoAspect"
+
+return IItemCargo

--- a/src/mod/elona/api/aspect/ItemCargoAspect.lua
+++ b/src/mod/elona/api/aspect/ItemCargoAspect.lua
@@ -1,0 +1,8 @@
+local ItemCargoAspect = class.class("ItemCargoAspect")
+
+function ItemCargoAspect:init(item, params)
+   self.cargo_weight = params.cargo_weight or 0
+   self.cargo_quality = params.cargo_quality or 0
+end
+
+return ItemCargoAspect

--- a/src/mod/elona/api/aspect/ItemCargoAspect.lua
+++ b/src/mod/elona/api/aspect/ItemCargoAspect.lua
@@ -1,4 +1,6 @@
-local ItemCargoAspect = class.class("ItemCargoAspect")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
+
+local ItemCargoAspect = class.class("ItemCargoAspect", IItemCargo)
 
 function ItemCargoAspect:init(item, params)
    self.cargo_weight = params.cargo_weight or 0

--- a/src/mod/elona/data/inventory_proto.lua
+++ b/src/mod/elona/data/inventory_proto.lua
@@ -19,6 +19,7 @@ local Const = require("api.Const")
 local World = require("api.World")
 local Item = require("api.Item")
 local God = require("mod.elona.api.God")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local function fail_in_world_map(ctxt)
    if ctxt.chara:current_map():has_type("world_map") then
@@ -468,7 +469,7 @@ local inv_sell = {
 
    filter = function(ctxt, item)
       -- >>>>>>>> shade2/command.hsp:3368 		if shopTrade{ ...
-      if (item:calc("cargo_weight") or 0) > 0 then
+      if item:get_aspect(IItemCargo) then
          return false
       end
 

--- a/src/mod/elona/data/item/cargo.lua
+++ b/src/mod/elona/data/item/cargo.lua
@@ -17,7 +17,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 1,
          cargo_weight = 6500
@@ -37,7 +37,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 2,
          cargo_weight = 10000
@@ -58,7 +58,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 4,
          cargo_weight = 50000
@@ -78,7 +78,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 5,
          cargo_weight = 4800
@@ -99,7 +99,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 3,
          cargo_weight = 12000
@@ -120,7 +120,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 0,
          cargo_weight = 10000
@@ -141,7 +141,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 3,
          cargo_weight = 48000
@@ -162,7 +162,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 0,
          cargo_weight = 7500
@@ -183,7 +183,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 2,
          cargo_weight = 16000
@@ -204,7 +204,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 1,
          cargo_weight = 32000
@@ -226,7 +226,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 5,
          cargo_weight = 1500
@@ -250,7 +250,7 @@ data:add {
 
    light = light.crystal_high,
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 6,
          cargo_weight = 60000
@@ -273,7 +273,7 @@ data:add {
 
    light = light.item,
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 6,
          cargo_weight = 11000
@@ -294,7 +294,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 7,
          cargo_weight = 35000
@@ -314,7 +314,7 @@ data:add {
       "elona.cargo"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 7,
          cargo_weight = 7000
@@ -340,7 +340,7 @@ data:add {
       "elona.cargo_food"
    },
 
-   ext = {
+   _ext = {
       [IItemCargo] = {
          cargo_quality = 0,
          cargo_weight = 2000

--- a/src/mod/elona/data/item/cargo.lua
+++ b/src/mod/elona/data/item/cargo.lua
@@ -1,4 +1,5 @@
 local light = require("mod.elona.data.item.light")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 --
 -- Cargo
@@ -10,16 +11,18 @@ data:add {
    elona_id = 399,
    image = "elona.item_rag_doll",
    value = 700,
-   cargo_weight = 6500,
-   is_cargo = true,
-   category = 92000,
    coefficient = 100,
-
-   params = { cargo_quality = 1 },
 
    categories = {
       "elona.cargo"
-   }
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 1,
+         cargo_weight = 6500
+      }
+   },
 }
 
 data:add {
@@ -28,16 +31,18 @@ data:add {
    elona_id = 400,
    image = "elona.item_barrel",
    value = 420,
-   cargo_weight = 10000,
-   is_cargo = true,
-   category = 92000,
    coefficient = 100,
-
-   params = { cargo_quality = 2 },
 
    categories = {
       "elona.cargo"
-   }
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 2,
+         cargo_weight = 10000
+      }
+   },
 }
 
 data:add {
@@ -46,16 +51,18 @@ data:add {
    elona_id = 401,
    image = "elona.item_piano",
    value = 4000,
-   cargo_weight = 50000,
-   is_cargo = true,
-   category = 92000,
    rarity = 200000,
    coefficient = 100,
 
-   params = { cargo_quality = 4 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 4,
+         cargo_weight = 50000
+      }
    }
 }
 
@@ -65,16 +72,18 @@ data:add {
    elona_id = 402,
    image = "elona.item_rope",
    value = 550,
-   cargo_weight = 4800,
-   is_cargo = true,
-   category = 92000,
    coefficient = 100,
-
-   params = { cargo_quality = 5 },
 
    categories = {
       "elona.cargo"
-   }
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 5,
+         cargo_weight = 4800
+      }
+   },
 }
 
 data:add {
@@ -83,16 +92,18 @@ data:add {
    elona_id = 403,
    image = "elona.item_coffin",
    value = 2200,
-   cargo_weight = 12000,
-   is_cargo = true,
-   category = 92000,
    rarity = 700000,
    coefficient = 100,
 
-   params = { cargo_quality = 3 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 3,
+         cargo_weight = 12000
+      }
    }
 }
 
@@ -102,16 +113,18 @@ data:add {
    elona_id = 404,
    image = "elona.item_manboo",
    value = 800,
-   cargo_weight = 10000,
-   is_cargo = true,
-   category = 92000,
    rarity = 1500000,
    coefficient = 100,
 
-   params = { cargo_quality = 0 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 0,
+         cargo_weight = 10000
+      }
    }
 }
 
@@ -121,16 +134,18 @@ data:add {
    elona_id = 405,
    image = "elona.item_grave",
    value = 2800,
-   cargo_weight = 48000,
-   is_cargo = true,
-   category = 92000,
    rarity = 800000,
    coefficient = 100,
 
-   params = { cargo_quality = 3 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 3,
+         cargo_weight = 48000
+      }
    }
 }
 
@@ -140,16 +155,18 @@ data:add {
    elona_id = 406,
    image = "elona.item_tuna_fish",
    value = 350,
-   cargo_weight = 7500,
-   is_cargo = true,
-   category = 92000,
    rarity = 2000000,
    coefficient = 100,
 
-   params = { cargo_quality = 0 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 0,
+         cargo_weight = 7500
+      }
    }
 }
 
@@ -159,16 +176,18 @@ data:add {
    elona_id = 407,
    image = "elona.item_whisky",
    value = 1400,
-   cargo_weight = 16000,
-   is_cargo = true,
-   category = 92000,
    rarity = 600000,
    coefficient = 100,
 
-   params = { cargo_quality = 2 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 2,
+         cargo_weight = 16000
+      }
    }
 }
 
@@ -178,16 +197,18 @@ data:add {
    elona_id = 408,
    image = "elona.item_noble_toy",
    value = 1200,
-   cargo_weight = 32000,
-   is_cargo = true,
-   category = 92000,
    rarity = 500000,
    coefficient = 100,
 
-   params = { cargo_quality = 1 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 1,
+         cargo_weight = 32000
+      }
    }
 }
 
@@ -197,16 +218,19 @@ data:add {
    elona_id = 409,
    image = "elona.item_inner_tube",
    value = 340,
-   cargo_weight = 1500,
    is_cargo = true,
-   category = 92000,
    rarity = 1500000,
    coefficient = 100,
 
-   params = { cargo_quality = 5 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 5,
+         cargo_weight = 1500
+      }
    }
 }
 
@@ -216,19 +240,22 @@ data:add {
    elona_id = 597,
    image = "elona.item_christmas_tree",
    value = 3500,
-   cargo_weight = 60000,
    is_cargo = true,
-   category = 92000,
    rarity = 600000,
    coefficient = 100,
-
-   params = { cargo_quality = 6 },
 
    categories = {
       "elona.cargo"
    },
 
-   light = light.crystal_high
+   light = light.crystal_high,
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 6,
+         cargo_weight = 60000
+      }
+   }
 }
 
 data:add {
@@ -237,19 +264,21 @@ data:add {
    elona_id = 598,
    image = "elona.item_snow_man",
    value = 1200,
-   cargo_weight = 11000,
-   is_cargo = true,
-   category = 92000,
    rarity = 800000,
    coefficient = 100,
-
-   params = { cargo_quality = 6 },
 
    categories = {
       "elona.cargo"
    },
 
-   light = light.item
+   light = light.item,
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 6,
+         cargo_weight = 11000
+      }
+   }
 }
 
 data:add {
@@ -258,16 +287,18 @@ data:add {
    elona_id = 669,
    image = "elona.item_painting_of_landscape",
    value = 3800,
-   cargo_weight = 35000,
-   is_cargo = true,
-   category = 92000,
    rarity = 150000,
    coefficient = 100,
 
-   params = { cargo_quality = 7 },
-
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 7,
+         cargo_weight = 35000
+      }
    }
 }
 
@@ -277,15 +308,17 @@ data:add {
    elona_id = 670,
    image = "elona.item_canvas",
    value = 750,
-   cargo_weight = 7000,
-   is_cargo = true,
-   category = 92000,
    coefficient = 100,
-
-   params = { cargo_quality = 7 },
 
    categories = {
       "elona.cargo"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 7,
+         cargo_weight = 7000
+      }
    }
 }
 
@@ -299,14 +332,18 @@ data:add {
    elona_id = 333,
    image = "elona.item_travelers_food",
    value = 40,
-   cargo_weight = 2000,
-   is_cargo = true,
-   category = 91000,
    coefficient = 100,
 
    params = { food_quality = 3 },
 
    categories = {
       "elona.cargo_food"
+   },
+
+   ext = {
+      [IItemCargo] = {
+         cargo_quality = 0,
+         cargo_weight = 2000
+      }
    }
 }

--- a/src/mod/elona/data/wish_handler.lua
+++ b/src/mod/elona/data/wish_handler.lua
@@ -354,7 +354,7 @@ local function extract_chara_id(wish)
 end
 
 local function adjust_potion_scroll_amount(item)
-   if item:has_category("elona.drink") or item:has_category("elona.drink_potion") then
+   if item:has_category("elona.drink") or item:has_category("elona.scroll") then
       item.amount = 3 + Rand.rnd(2)
       if item.value >= 5000 then
          item.amount = 3

--- a/src/mod/elona/events/map.lua
+++ b/src/mod/elona/events/map.lua
@@ -11,10 +11,7 @@ local Equipment = require("mod.elona.api.Equipment")
 local Gui = require("api.Gui")
 local ElonaAction = require("mod.elona.api.ElonaAction")
 local Const = require("api.Const")
-local Map = require("api.Map")
-local Feat = require("api.Feat")
-local Filters = require("mod.elona.api.Filters")
-local MapgenUtils = require("mod.elona.api.MapgenUtils")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 local function decrease_nutrition(chara, params, result)
    -- >>>>>>>> shade2/calculation.hsp:1274 		if cHunger(r1)<hungerHungry{ ...
@@ -134,7 +131,7 @@ local function on_map_renew_minor(map)
                   quality = Calc.calc_object_quality(Enum.Quality.Normal),
                }
                local item = Itemgen.create(nil, nil, filter, chara)
-               if (item:calc("cargo_weight") or 0) > 0 or item:calc("weight") <= 0 or item:calc("weight") >= 4000 then
+               if item:get_aspect(IItemCargo) or item:calc("weight") <= 0 or item:calc("weight") >= 4000 then
                   item.amount = 0
                   item:remove_ownership()
                end

--- a/src/scratch/2021-03-30_00-47-57.lua
+++ b/src/scratch/2021-03-30_00-47-57.lua
@@ -1,11 +1,11 @@
 local ArchiveUnpacker = require("mod.cdata_tools.api.archive.ArchiveUnpacker")
 local Log = require("api.Log")
-local CustomItemDecoder = require("mod.cdata_tools.api.citem.CustomItemDecoder")
 local CodeGenerator = require("api.CodeGenerator")
 local fs = require("util.fs")
 local paths = require("internal.paths")
-local CustomNpcDecoder = require("mod.cdata_tools.api.cnpc.CustomNpcDecoder")
-local CustomGodDecoder = require("mod.cdata_tools.api.cnpc.CustomGodDecoder")
+local CustomItemDecoder = require("mod.cdata_tools.api.decoder.CustomItemDecoder")
+local CustomNpcDecoder = require("mod.cdata_tools.api.decoder.CustomNpcDecoder")
+local CustomGodDecoder = require("mod.cdata_tools.api.decoder.CustomGodDecoder")
 
 Log.set_level("debug")
 

--- a/src/scratch/2021-04-16_18-06-57.lua
+++ b/src/scratch/2021-04-16_18-06-57.lua
@@ -1,0 +1,252 @@
+local Enum = require("api.Enum")
+local Skill = require("mod.elona_sys.api.Skill")
+local Gui = require("api.Gui")
+local Input = require("api.Input")
+local Item = require("api.Item")
+local Magic = require("mod.elona_sys.api.Magic")
+
+data:add {
+   _id = "artifact",
+   _type = "base.item",
+   custom_author = "円環の女神",
+   damage_bonus = 10,
+   dice_x = 5,
+   dice_y = 10,
+   dv = 2,
+   effective_range = { 50, 90, 100, 100, 90, 70, 70, 60, 60, 50 },
+   hit_bonus = 10,
+   identify_difficulty = 500,
+   level = 800,
+   material = "elona.rubynus",
+   on_use = function(self, params)
+      return true
+   end,
+   pierce_rate = 20,
+   pv = 2,
+   quality = Enum.Quality.Unique,
+   rarity = 1000000,
+   skill = "elona.bow",
+   value = 5000,
+   weight = 1500
+}
+
+data:add {
+   _id = "artifact",
+   _type = "base.item",
+   custom_author = "円環の女神",
+
+   identify_difficulty = 500,
+   level = 800,
+   material = "elona.rubynus",
+   quality = Enum.Quality.Unique,
+   rarity = 1000000,
+   value = 5000,
+   weight = 1500,
+
+   ext = {
+      ["base.equipment"] = {
+         damage_bonus = 10,
+         dice_x = 5,
+         dice_y = 10,
+         dv = 2,
+         hit_bonus = 10,
+         pierce_rate = 20,
+         pv = 2,
+         skill = "elona.bow",
+      },
+      ["base.ranged_weapon"] = {
+         effective_range = { 50, 90, 100, 100, 90, 70, 70, 60, 60, 50 },
+      },
+      ["base.useable"] = {
+         on_use = function(self, params)
+            return true
+         end
+      }
+   },
+}
+
+data:add {
+   _type = "base.item",
+   _id = "thick_gauntlets",
+
+   elona_id = 10,
+   image = "elona.item_thick_gauntlets",
+   value = 400,
+   weight = 1100,
+   material = "elona.metal",
+   coefficient = 100,
+   categories = {
+      "elona.equip_wrist_gauntlet",
+      "elona.equip_wrist"
+   },
+
+   ext = {
+      ["base.equipment"] = {
+         hit_bonus = 2,
+         damage_bonus = 1,
+         pv = 4,
+         dv = 2,
+         equip_slots = { "elona.arm" },
+      }
+   }
+}
+
+local IScrollAspect = class.interface("IScrollAspect",
+                                      { effects = "table", },
+                                      { IAItemReadable })
+
+local ScrollAspect = class.class("ScrollAspect", IScrollAspect)
+
+function ScrollAspect:init(item, params)
+   self.effects = params.effects or {}
+end
+
+function ScrollAspect:on_read(item, params)
+   return Magic.read_scroll(params.chara, self.effects)
+end
+
+local ConfirmableScrollAspect = class.class("ConfirmableScrollAspect", IScrollAspect)
+
+ConfirmableScrollAspect:delegate("inner", IScrollAspect)
+
+function ConfirmableScrollAspect:init(item, params)
+   self.inner = ScrollAspect:new(item, params)
+end
+
+function ConfirmableScrollAspect:on_read(item, params)
+   if not Input.yes_no() then
+      return "player_turn_query"
+   end
+   return self.inner:on_read(item, params)
+end
+
+data:add {
+   _type = "base.item",
+   _id = "scroll_of_incognito",
+
+   elona_id = 17,
+   image = "elona.item_scroll",
+   value = 3500,
+   weight = 20,
+   rarity = 70000,
+   coefficient = 0,
+
+   categories = {
+      "elona.scroll",
+   },
+
+   -- on_read = function(self, params)
+   --    return ElonaMagic.read_scroll(self, {{ _id = "elona.buff_incognito", power = 300 }}, params)
+   -- end,
+
+   ext = {
+      ["elona.unknown_item"] = {
+         knownnameref = "scroll",
+         originalnameref2 = "scroll",
+         has_random_name = true,
+         random_color = "Random",
+      },
+      [IScrollAspect] = {
+         effects = {
+            { _id = "elona.buff_incognito", power = 300 }
+         }
+      }
+   }
+}
+
+data:add {
+   _type = "base.item",
+   _id = "lemon",
+
+   elona_id = 197,
+   image = "elona.item_magic_fruit",
+   value = 240,
+   weight = 440,
+   material = "elona.fresh",
+   category = 57000,
+   subcategory = 57004,
+   coefficient = 100,
+
+   categories = {
+      "elona.food_fruit",
+      "elona.food"
+   },
+
+   ext = {
+      ["base.food"] = {
+         food_type = "elona.fruit",
+         spoilage_hours = 12
+      }
+   }
+}
+
+data:add {
+   _type = "base.extension",
+   _id = "food",
+
+   applies_to = "base.item",
+
+   on_build = function(self, params)
+      local p = get_param(params, IAItemFood)
+      local aspect = self:get_aspect_or_default(IAItemFood, p)
+   end
+}
+
+local ITextbookAspect = class.interface("ITextbookAspect",
+                                        { skill_id = "string", },
+                                        { IAItemReadable })
+
+data:add {
+   _type = "base.ext",
+   _id = "textbook",
+
+   aspect = ITextbookAspect
+}
+
+local TextbookAspect = class.class("TextbookAspect", ITextbookAspect)
+
+function TextbookAspect:init(item, params)
+   -- >>>>>>>> shade2/item.hsp:619 	if iId(ci)=idBookSkill	:if iBookId(ci)=0:iBookId( ..
+   self.skill_id = params.skill_id or Skill.random_skill()
+   -- <<<<<<<< shade2/item.hsp:619 	if iId(ci)=idBookSkill	:if iBookId(ci)=0:iBookId( ..
+end
+
+function TextbookAspect:on_read(item, params)
+   local skill_id = self.skill_id
+   local chara = params.chara
+   if chara:is_player() and not chara:has_skill(skill_id) then
+      Gui.mes("action.read.book.not_interested")
+      if not Input.yes_no() then
+         return "player_turn_query"
+      end
+   end
+
+   chara:start_activity("elona.training", {skill_id=skill_id,item=item})
+
+   return "turn_end"
+end
+
+data:add {
+   _type = "base.item",
+   _id = "textbook",
+
+   elona_id = 563,
+   image = "elona.item_textbook",
+   value = 4800,
+   weight = 80,
+   category = 55000,
+   rarity = 50000,
+   coefficient = 100,
+
+   ext = {
+      ITextbookAspect
+   },
+
+   categories = {
+      "elona.book"
+   }
+}
+
+local textbook = Item.create("elona.textbook", nil, nil, { ownerless = true, params = { [ITextbookAspect] = { skill_id = "elona.evasion" } } })
+local aspect = textbook:get_aspect_or_default(ITextbookAspect)
+print(aspect.skill_id)

--- a/src/test/api/Aspect.lua
+++ b/src/test/api/Aspect.lua
@@ -1,0 +1,14 @@
+local Aspect = require("api.Aspect")
+local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
+local AspectHolder_TestAspect = require("test.api.AspectHolder_TestAspect")
+local AspectHolder_TestAspectModdable = require("test.api.AspectHolder_TestAspectModdable")
+local Assert = require("api.test.Assert")
+
+function test_Aspect_set_default_impl()
+   local impl = Aspect.get_default_impl(AspectHolder_ITestAspect)
+   Assert.eq(AspectHolder_TestAspect, impl)
+
+   Aspect.set_default_impl(AspectHolder_ITestAspect, AspectHolder_TestAspectModdable)
+   impl = Aspect.get_default_impl(AspectHolder_ITestAspect)
+   Assert.eq(AspectHolder_TestAspectModdable, impl)
+end

--- a/src/test/api/AspectHolder_ITestAspect.lua
+++ b/src/test/api/AspectHolder_ITestAspect.lua
@@ -1,0 +1,7 @@
+local IAspect = require("api.IAspect")
+
+local AspectHolder_ITestAspect = class.interface("ITestAspect", { foo = "number", }, { IAspect })
+
+AspectHolder_ITestAspect.default_impl = "test.api.AspectHolder_TestAspect"
+
+return AspectHolder_ITestAspect

--- a/src/test/api/AspectHolder_ITestAspect.lua
+++ b/src/test/api/AspectHolder_ITestAspect.lua
@@ -1,6 +1,6 @@
 local IAspect = require("api.IAspect")
 
-local AspectHolder_ITestAspect = class.interface("ITestAspect", { foo = "number", }, { IAspect })
+local AspectHolder_ITestAspect = class.interface("ITestAspect", { foo = "number" }, { IAspect })
 
 AspectHolder_ITestAspect.default_impl = "test.api.AspectHolder_TestAspect"
 

--- a/src/test/api/AspectHolder_TestAspect.lua
+++ b/src/test/api/AspectHolder_TestAspect.lua
@@ -1,0 +1,9 @@
+local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
+
+local AspectHolder_TestAspect = class.class("AspectHolder_TestAspect", AspectHolder_ITestAspect)
+
+function AspectHolder_TestAspect:init(target, params)
+   self.foo = params.my_foo or 0
+end
+
+return AspectHolder_TestAspect

--- a/src/test/api/AspectHolder_TestAspect.lua
+++ b/src/test/api/AspectHolder_TestAspect.lua
@@ -1,6 +1,6 @@
 local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
 
-local AspectHolder_TestAspect = class.class("AspectHolder_TestAspect", AspectHolder_ITestAspect)
+local AspectHolder_TestAspect = class.class("TestAspect", AspectHolder_ITestAspect)
 
 function AspectHolder_TestAspect:init(target, params)
    self.foo = params.my_foo or 0

--- a/src/test/api/AspectHolder_TestAspectModdable.lua
+++ b/src/test/api/AspectHolder_TestAspectModdable.lua
@@ -1,0 +1,28 @@
+local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
+local IAspectModdable = require("api.IAspectModdable")
+
+local AspectHolder_TestAspectModdable = class.class("TestAspectModdable", AspectHolder_ITestAspect)
+
+function AspectHolder_TestAspectModdable:init(target, params)
+   self.foo = params.my_foo or 0
+end
+
+function AspectHolder_TestAspectModdable:calc(target, prop)
+   local v = IAspectModdable.calc(self, target, "foo")
+
+   if prop == "foo" then
+      return v * 100
+   end
+
+   return v
+end
+
+function AspectHolder_TestAspectModdable:mod(target, prop, v, params)
+   if prop == "foo" then
+      v = v + 42
+   end
+
+   return IAspectModdable.mod(self, target, prop, v, params)
+end
+
+return AspectHolder_TestAspectModdable

--- a/src/test/api/IAspectHolder.lua
+++ b/src/test/api/IAspectHolder.lua
@@ -11,7 +11,7 @@ function test_IAspectHolder_normal_build()
       _type = "base.item",
       _id = "aspected",
 
-      ext = {
+      _ext = {
          AspectHolder_ITestAspect
       }
    }
@@ -19,6 +19,7 @@ function test_IAspectHolder_normal_build()
    local item = Item.create("@test@.aspected", nil, nil, {ownerless = true})
 
    Assert.eq(1, IAspectHolder.iter_aspects(item):length())
+   Assert.eq(nil, item._ext)
 
    local aspect = IAspectHolder.get_aspect(item, AspectHolder_ITestAspect)
    Assert.eq(true, class.is_an(AspectHolder_TestAspect, aspect))
@@ -30,7 +31,7 @@ function test_IAspectHolder_normal_build__params()
       _type = "base.item",
       _id = "aspected_with_params",
 
-      ext = {
+      _ext = {
          [AspectHolder_ITestAspect] = {
             my_foo = 42
          }

--- a/src/test/api/IAspectHolder.lua
+++ b/src/test/api/IAspectHolder.lua
@@ -85,3 +85,17 @@ function test_IAspectHolder_calc__custom_moddable_impl()
    Assert.eq(42, aspect.foo)
    Assert.eq(4200, aspect:calc(item, "foo"))
 end
+
+function test_IAspectHolder_calc_aspect()
+   local item = Item.create("@test@.aspected_with_params", nil, nil, {ownerless = true})
+
+   Assert.eq(42, item:calc_aspect(AspectHolder_ITestAspect, "foo"))
+
+   item:mod_aspect(AspectHolder_ITestAspect, "foo", 10, "add")
+
+   Assert.eq(52, item:calc_aspect(AspectHolder_ITestAspect, "foo"))
+
+   item:refresh()
+
+   Assert.eq(42, item:calc_aspect(AspectHolder_ITestAspect, "foo"))
+end

--- a/src/test/api/IAspectHolder.lua
+++ b/src/test/api/IAspectHolder.lua
@@ -1,6 +1,7 @@
 local data = require("internal.data")
-local AspectHolder_TestAspect = require("test.api.AspectHolder_TestAspect")
 local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
+local AspectHolder_TestAspect = require("test.api.AspectHolder_TestAspect")
+local AspectHolder_TestAspectModdable = require("test.api.AspectHolder_TestAspectModdable")
 local Item = require("api.Item")
 local Assert = require("api.test.Assert")
 local IAspectHolder = require("api.IAspectHolder")
@@ -43,4 +44,44 @@ function test_IAspectHolder_normal_build__params()
    local aspect = IAspectHolder.get_aspect(item, AspectHolder_ITestAspect)
    Assert.eq(true, class.is_an(AspectHolder_TestAspect, aspect))
    Assert.eq(42, aspect.foo)
+end
+
+function test_IAspectHolder_calc()
+   local item = Item.create("@test@.aspected_with_params", nil, nil, {ownerless = true})
+
+   local aspect = IAspectHolder.get_aspect(item, AspectHolder_ITestAspect)
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(42, aspect:calc(item, "foo"))
+
+   aspect:mod(item, "foo", 10, "add")
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(52, aspect:calc(item, "foo"))
+
+   item:refresh()
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(42, aspect:calc(item, "foo"))
+end
+
+function test_IAspectHolder_calc__custom_moddable_impl()
+   local item = Item.create("@test@.aspected_with_params", nil, nil, {ownerless = true})
+
+   local aspect = AspectHolder_TestAspectModdable:new(item, { my_foo = 42 })
+   item:set_aspect(AspectHolder_ITestAspect, aspect)
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(4200, aspect:calc(item, "foo"))
+
+   aspect:mod(item, "foo", 10, "add")
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(94, aspect.temp["foo"])
+   Assert.eq(9400, aspect:calc(item, "foo"))
+
+   item:refresh()
+
+   Assert.eq(42, aspect.foo)
+   Assert.eq(4200, aspect:calc(item, "foo"))
 end

--- a/src/test/api/IAspectHolder.lua
+++ b/src/test/api/IAspectHolder.lua
@@ -1,0 +1,46 @@
+local data = require("internal.data")
+local AspectHolder_TestAspect = require("test.api.AspectHolder_TestAspect")
+local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
+local Item = require("api.Item")
+local Assert = require("api.test.Assert")
+local IAspectHolder = require("api.IAspectHolder")
+
+function test_IAspectHolder_normal_build()
+   data:add {
+      _type = "base.item",
+      _id = "aspected",
+
+      ext = {
+         AspectHolder_ITestAspect
+      }
+   }
+
+   local item = Item.create("@test@.aspected", nil, nil, {ownerless = true})
+
+   Assert.eq(1, IAspectHolder.iter_aspects(item):length())
+
+   local aspect = IAspectHolder.get_aspect(item, AspectHolder_ITestAspect)
+   Assert.eq(true, class.is_an(AspectHolder_TestAspect, aspect))
+   Assert.eq(0, aspect.foo)
+end
+
+function test_IAspectHolder_normal_build__params()
+   data:add {
+      _type = "base.item",
+      _id = "aspected_with_params",
+
+      ext = {
+         [AspectHolder_ITestAspect] = {
+            my_foo = 42
+         }
+      }
+   }
+
+   local item = Item.create("@test@.aspected_with_params", nil, nil, {ownerless = true})
+
+   Assert.eq(1, IAspectHolder.iter_aspects(item):length())
+
+   local aspect = IAspectHolder.get_aspect(item, AspectHolder_ITestAspect)
+   Assert.eq(true, class.is_an(AspectHolder_TestAspect, aspect))
+   Assert.eq(42, aspect.foo)
+end

--- a/src/test/api/IStackableObject.lua
+++ b/src/test/api/IStackableObject.lua
@@ -3,6 +3,7 @@ local Assert = require("api.test.Assert")
 local InstancedMap = require("api.InstancedMap")
 local Chara = require("api.Chara")
 local TestUtil = require("api.test.TestUtil")
+local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 
 function test_IStackableObject_separate__single()
    local item = TestUtil.stripped_item("elona.putitoro")
@@ -140,6 +141,22 @@ function test_IStackableObject_can_stack_with__separated_in_map()
 
    Assert.eq(true, item:can_stack_with(sep))
    Assert.eq(true, sep:can_stack_with(item))
+end
+
+function test_IStackableObject_stack__aspect()
+   local map = InstancedMap:new(10, 10)
+   map:clear("elona.cobble")
+
+   local item = TestUtil.stripped_item("elona.cargo_piano", map, 1, 1, 5)
+   local sep = item:separate(2)
+
+   Assert.eq(true, item:can_stack_with(sep))
+   Assert.eq(true, sep:can_stack_with(item))
+
+   sep:mod_aspect(IItemCargo, "cargo_weight", 10, "add")
+
+   Assert.eq(false, item:can_stack_with(sep))
+   Assert.eq(false, sep:can_stack_with(item))
 end
 
 function test_IStackableObject_stack()

--- a/src/tools/cli/commands/test.lua
+++ b/src/tools/cli/commands/test.lua
@@ -18,6 +18,7 @@ local TestUtil = require("api.test.TestUtil")
 local Advice = require("api.Advice")
 local main_state = require("internal.global.main_state")
 local Env = require("api.Env")
+local aspect_state = require("internal.global.aspect_state")
 
 local function reset_all_globals()
    Log.debug("Resetting global state.")
@@ -107,6 +108,7 @@ local function cleanup_globals()
    fs.remove(SaveFs.save_path("", "global"))
    field:init_global_data()
    Advice.remove_by_mod(TestUtil.TEST_MOD_ID)
+   table.replace_with(aspect_state.default_impls, {})
    Env.clear_ui_results()
 
    config_store.proxy().base.autosave = false

--- a/src/util/class.lua
+++ b/src/util/class.lua
@@ -213,7 +213,7 @@ end
 function class.assert_is_an(interface, obj)
    local ok = class.is_an(interface, obj)
    if not ok then
-      local err = ""
+      local err = nil
       if type(obj) ~= "table" then
          err = ("Needed class '%s', got value of type '%s'"):format(tostring(interface), type(obj))
       end
@@ -443,8 +443,12 @@ function class.class(name, ifaces, opts)
    return setmetatable(c, class_mt)
 end
 
-function class.is_class_or_interface(tbl)
-   return _classes[tbl] or _interfaces[tbl]
+function class.is_class(tbl)
+   return not not _classes[tbl]
+end
+
+function class.is_interface(tbl)
+   return not not _interfaces[tbl]
 end
 
 function class.is_class_instance(tbl)


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [ ] Enhancement
- [x] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

Close #15.

### Description
Implements an "aspect" system, which is synonymous with the capability system described in previous issues. It allows you to add new functionality to instanced map objects.

```lua
local aspect = cargo:get_aspect_or_default(IItemCargo)
aspect.cargo_weight = 25000

cargo:set_aspect(IItemCargo, ItemCargoAspect:new(cargo, { cargo_quality = 5 })
```

Aspects support temporary values, to allow for using `:calc()` as before. Using aspects, you'd be able to override the behavior of an interface that encompasses `IAspect`, even for things like property accesses through temporary values. From the unit tests:

```lua
local AspectHolder_ITestAspect = require("test.api.AspectHolder_ITestAspect")
local IAspectModdable = require("api.IAspectModdable")

local AspectHolder_TestAspectModdable = class.class("TestAspectModdable", AspectHolder_ITestAspect)

function AspectHolder_TestAspectModdable:init(target, params)
   self.foo = params.my_foo or 0
end

function AspectHolder_TestAspectModdable:calc(target, prop)
   local v = IAspectModdable.calc(self, target, "foo")

   if prop == "foo" then
      return v * 100
   end

   return v
end

function AspectHolder_TestAspectModdable:mod(target, prop, v, params)
   if prop == "foo" then
      v = v + 42
   end

   return IAspectModdable.mod(self, target, prop, v, params)
end

return AspectHolder_TestAspectModdable
```

Finally, a new `_ext` table is now supported on all prototypes for map objects, which lets you specify which aspects should get instantiated on object creation, and their parameters. The parameters will get passed to the constructor along with the object instance.

```lua
data:add {
   _type = "base.item",
   _id = "aspected",

   _ext = {
      AspectHolder_ITestAspect
   }
}

data:add {
   _type = "base.item",
   _id = "cargo_art",
   elona_id = 669,
   image = "elona.item_painting_of_landscape",
   value = 3800,
   rarity = 150000,
   coefficient = 100,

   categories = {
      "elona.cargo"
   },

   _ext = {
      [IItemCargo] = {
         cargo_quality = 7,
         cargo_weight = 35000
      }
   }
}
```

The end goal is to replace the usages of `item:has_category()` and similar for determining if an item "acts like" equipment, cargo, and so on. Item categories are still useful for things like item generation, so they will stay for the time being.

The parts of the cargo system that were implemented have been updated to use aspects.