### PR TITLE
Make equipment items use aspects

### DIFF
--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -68,6 +68,14 @@ function IAspectHolder:set_aspect(iface, aspect)
    self._aspects:set_aspect(self, iface, aspect)
 end
 
+function IAspectHolder:get_aspect_proto(iface)
+   local _ext = self.proto._ext
+   if not _ext then
+      return
+   end
+   return _ext[iface]
+end
+
 function IAspectHolder:iter_aspects(iface)
    if iface then
       return self:iter_aspects():filter(function(a) return class.is_an(iface, a) end)

--- a/src/api/IAspectHolder.lua
+++ b/src/api/IAspectHolder.lua
@@ -71,9 +71,20 @@ end
 function IAspectHolder:get_aspect_proto(iface)
    local _ext = self.proto._ext
    if not _ext then
-      return
+      return nil
    end
-   return _ext[iface]
+   if _ext[iface] then
+      return _ext[iface]
+   end
+
+   -- iterate list part of table
+   for _, item in ipairs(_ext) do
+      if item == iface then
+         return {}
+      end
+   end
+
+   return nil
 end
 
 function IAspectHolder:iter_aspects(iface)

--- a/src/api/chara/ICharaEquip.lua
+++ b/src/api/chara/ICharaEquip.lua
@@ -28,10 +28,8 @@ local function apply_item_stats(chara, item)
    chara:mod("equipment_weight", item:calc("weight"), "add")
 
    local equip = assert(item:get_aspect(IItemEquipment))
-   if equip then
-      chara:mod("dv", equip:calc(item, "dv"), "add")
-      chara:mod("pv", equip:calc(item, "pv"), "add")
-   end
+   chara:mod("dv", equip:calc(item, "dv"), "add")
+   chara:mod("pv", equip:calc(item, "pv"), "add")
 
    if item:calc("is_melee_weapon") then
       chara:mod("number_of_weapons", 1, "add")

--- a/src/api/chara/ICharaEquip.lua
+++ b/src/api/chara/ICharaEquip.lua
@@ -3,6 +3,7 @@ local EquipSlots = require("api.EquipSlots")
 local ICharaInventory = require("api.chara.ICharaInventory")
 local data = require("internal.data")
 local Enum = require("api.Enum")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 local ICharaEquip = class.interface("ICharaEquip", {}, ICharaInventory)
 
@@ -25,14 +26,18 @@ end
 local function apply_item_stats(chara, item)
    -- >>>>>>>> shade2/calculation.hsp:434 	cEqWeight(r1)+=iWeight(rp) ..
    chara:mod("equipment_weight", item:calc("weight"), "add")
-   chara:mod("dv", item:calc("dv"), "add")
-   chara:mod("pv", item:calc("pv"), "add")
-   chara:mod("hit_bonus", item:calc("hit_bonus"), "add")
-   chara:mod("damage_bonus", item:calc("damage_bonus"), "add")
+
+   local equip = assert(item:get_aspect(IItemEquipment))
+   if equip then
+      chara:mod("dv", equip:calc(item, "dv"), "add")
+      chara:mod("pv", equip:calc(item, "pv"), "add")
+   end
 
    if item:calc("is_melee_weapon") then
       chara:mod("number_of_weapons", 1, "add")
    elseif item:calc("is_armor") then
+      chara:mod("hit_bonus", equip:calc(item, "hit_bonus"), "add")
+      chara:mod("damage_bonus", equip:calc(item, "damage_bonus"), "add")
       local bonus = 0
       if item:is_blessed() then
          bonus = 2

--- a/src/api/gui/menu/EquipmentMenu.lua
+++ b/src/api/gui/menu/EquipmentMenu.lua
@@ -277,7 +277,7 @@ function EquipmentMenu:update(dt)
       else
          local result, query_canceled = Input.query_item(self.chara, "elona.inv_equip", { params = {body_part_id = entry.body_part._id} })
          if not query_canceled then
-            local selected_item = result.result
+            local selected_item = result.result:separate()
             assert(Action.equip(self.chara, selected_item, slot))
             -- >>>>>>>> shade2/command.hsp:3743 			snd seEquip ..
             Gui.play_sound("base.equip1")

--- a/src/api/item/IItem.lua
+++ b/src/api/item/IItem.lua
@@ -13,6 +13,7 @@ local Gui = require("api.Gui")
 local data = require("internal.data")
 local Enum = require("api.Enum")
 local IComparable = require("api.IComparable")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 local IItem = class.interface("IItem",
                          {},
@@ -186,11 +187,12 @@ end
 --- @tparam id:base.body_part body_part_type
 --- @treturn bool
 function IItem:can_equip_at(body_part_type)
-   local equip_slots = self:calc("equip_slots") or {}
-   if #equip_slots == 0 then
-      return nil
+   local equip = self:get_aspect(IItemEquipment)
+   if equip == nil then
+      return false
    end
 
+   local equip_slots = equip:calc(self, "equip_slots") or {}
    local can_equip = table.set(equip_slots)
 
    return can_equip[body_part_type] == true

--- a/src/api/test/TestUtil.lua
+++ b/src/api/test/TestUtil.lua
@@ -9,6 +9,7 @@ local Enum = require("api.Enum")
 local IItem = require("api.item.IItem")
 local env = require("internal.env")
 local hotload = require("internal.hotload")
+local ItemMaterial = require("mod.elona.api.ItemMaterial")
 
 local TestUtil = {}
 
@@ -50,6 +51,7 @@ function TestUtil.stripped_chara(id, map, x, y)
    chara:iter_items():each(IItem.remove_ownership)
    -- TODO event
    chara.god = nil
+   chara:refresh()
    return chara
 end
 
@@ -61,6 +63,7 @@ function TestUtil.stripped_item(id, map, x, y, amount, aspects)
       item = Item.create(id, x, y, {amount=amount or 1,aspects=aspects}, map)
    end
    item.curse_state = Enum.CurseState.Normal
+   ItemMaterial.change_item_material(item, nil)
    return item
 end
 

--- a/src/internal/data/schemas.lua
+++ b/src/internal/data/schemas.lua
@@ -532,12 +532,6 @@ dungeons.
             template = true
          },
          {
-            name = "equip_slots",
-            default = {},
-            type = "table",
-            template = true
-         },
-         {
             name = "on_read",
             default = nil,
             type = "function(IItem,IChara)?"

--- a/src/internal/events/item_description.lua
+++ b/src/internal/events/item_description.lua
@@ -3,6 +3,7 @@ local Const = require("api.Const")
 local Enum = require("api.Enum")
 local I18N = require("api.I18N")
 local Event = require("api.Event")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 
 -- >>>>>>>> shade2/command.hsp:4108 		if iMaterial(ci)!0		:list(0,p)=7:listN(0,p)=lang ..
@@ -117,21 +118,25 @@ local quality_info = {
    },
    {
       pred = function(i)
+         local equip = i:get_aspect(IItemEquipment)
          return i:calc("identify_state") >= Enum.IdentifyState.Full
-            and (i:calc("hit_bonus") > 0 or i:calc("damage_bonus") > 0)
+            and equip and (equip:calc(i, "hit_bonus") > 0 or equip:calc(i, "damage_bonus") > 0)
       end,
       desc = function(i)
-         return I18N.get("item.desc.bonus", i:calc("hit_bonus"), i:calc("damage_bonus"))
+         local equip = i:get_aspect(IItemEquipment)
+         return I18N.get("item.desc.bonus", equip:calc(i, "hit_bonus"), equip:calc(i, "damage_bonus"))
       end,
       icon = 5
    },
    {
       pred = function(i)
+         local equip = i:get_aspect(IItemEquipment)
          return i:calc("identify_state") >= Enum.IdentifyState.Full
-            and (i:calc("dv") > 0 or i:calc("pv") > 0)
+            and equip and (equip:calc(i, "dv") > 0 or equip:calc(i, "pv") > 0)
       end,
       desc = function(i)
-         return I18N.get("item.desc.dv_pv", i:calc("dv"), i:calc("pv"))
+         local equip = i:get_aspect(IItemEquipment)
+         return I18N.get("item.desc.dv_pv", equip:calc(i, "dv"), equip:calc(i, "pv"))
       end,
       icon = 6
    },

--- a/src/mod/elona/api/Combat.lua
+++ b/src/mod/elona/api/Combat.lua
@@ -3,6 +3,7 @@ local Const = require("api.Const")
 local Event = require("api.Event")
 local Rand = require("api.Rand")
 local Pos = require("api.Pos")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 local Combat = {}
 
@@ -14,15 +15,16 @@ local function calc_accuracy_default(chara, weapon, attack_skill, ammo, params)
    local accuracy
 
    if weapon then
+      local equip = assert(weapon:get_aspect(IItemEquipment))
       accuracy = chara:skill_level("elona.stat_dexterity") / 4
          + chara:skill_level(weapon:calc("skill") or "elona.martial_arts") / 3
          + chara:skill_level(attack_skill)
          + 50
          + chara:calc("hit_bonus")
-         + weapon:calc("hit_bonus")
+         + equip:calc(weapon, "hit_bonus")
 
       if ammo then
-         accuracy = accuracy + ammo:calc("hit_bonus")
+         accuracy = accuracy + ammo:calc_aspect(IItemEquipment, "hit_bonus")
       end
    else
       accuracy = chara:skill_level("elona.stat_dexterity") / 5
@@ -314,7 +316,7 @@ end
 
 local function calc_damage_params_default(chara, weapon, target, attack_skill, ammo)
    -- >>>>>>>> shade2/calculation.hsp:256 		dmgFix	= cDmg(cc) + iDmg(cw) +iLevel(cw)+(iStatu ..
-   local dmgfix = chara:calc("damage_bonus") + weapon:calc("damage_bonus") + weapon:calc("bonus")
+   local dmgfix = chara:calc("damage_bonus") + weapon:calc_aspect(IItemEquipment, "damage_bonus") + weapon:calc("bonus")
    if weapon:is_blessed() then
       dmgfix = dmgfix + 1
    end
@@ -323,7 +325,7 @@ local function calc_damage_params_default(chara, weapon, target, attack_skill, a
 
    local multiplier
    if ammo then
-      dmgfix = dmgfix + ammo:calc("damage_bonus") + ammo:calc("dice_x") * ammo:calc("dice_y") / 2
+      dmgfix = dmgfix + ammo:calc_aspect(IItemEquipment, "damage_bonus") + ammo:calc("dice_x") * ammo:calc("dice_y") / 2
       multiplier = 0.5
          + (chara:skill_level("elona.stat_perception")
                + chara:skill_level(weapon:calc("skill") or "elona.throwing") / 5

--- a/src/mod/elona/api/Equipment.lua
+++ b/src/mod/elona/api/Equipment.lua
@@ -10,6 +10,7 @@ local Log = require("api.Log")
 local News = require("mod.elona.api.News")
 local text = require("thirdparty.pl.text")
 local I18N = require("api.I18N")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 local Equipment = {}
 
@@ -26,11 +27,14 @@ end
 
 function Equipment.equip_optimally(chara, item)
    -- >>>>>>>> shade2/adv.hsp:176 *chara_equip ...
-   if item.equip_slots == nil then
+   local equip = item:get_aspect(IItemEquipment)
+   if equip == nil then
       return
    end
 
-   for _, body_part in ipairs(item.equip_slots) do
+   local equip_slots = equip:calc(item, "equip_slots") or {}
+
+   for _, body_part in ipairs(equip_slots) do
       local slot = chara:find_equip_slot_for(item, body_part)
       if slot then
          assert(chara:equip_item(item))
@@ -279,7 +283,7 @@ body_to_specs["elona.back"] = { "elona.cloak" }
 body_to_specs["elona.waist"] = { "elona.girdle" }
 body_to_specs["elona.head"] = { "elona.helmet" }
 body_to_specs["elona.body"] = { "elona.armor" }
-body_to_specs["elona.wrist"] = { "elona.gloves" }
+body_to_specs["elona.arm"] = { "elona.gloves" }
 body_to_specs["elona.leg"] = { "elona.boots" }
 body_to_specs["elona.hand"] = {
    "elona.multi_weapon",

--- a/src/mod/elona/api/Itemname.lua
+++ b/src/mod/elona/api/Itemname.lua
@@ -20,6 +20,7 @@ local Hunger = require("mod.elona.api.Hunger")
 local IItemCargo = require("mod.elona.api.aspect.IItemCargo")
 local IItemFood = require("mod.elona.api.aspect.IItemFood")
 local IItemFromChara = require("mod.elona.api.aspect.IItemFromChara")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 local Itemname = {}
 
@@ -43,13 +44,14 @@ local function item_known_info(item)
       s = s .. I18N.get("item.charges", item.charges)
    end
 
+   local equip = item:get_aspect(IItemEquipment)
+
    local dice_x = item:calc("dice_x") or 0
    local dice_y = item:calc("dice_y") or 0
-   local damage_bonus = item:calc("damage_bonus") or 0
+   local hit_bonus = (equip and equip:calc(item, "hit_bonus")) or 0
+   local damage_bonus = (equip and equip:calc(item, "damage_bonus")) or 0
 
-   if dice_x ~= 0 or item.hit_bonus ~= 0 or damage_bonus ~= 0 then
-      local hit_bonus = item:calc("hit_bonus") or 0
-
+   if dice_x ~= 0 or hit_bonus ~= 0 or damage_bonus ~= 0 then
       s = s .. " ("
       if dice_x ~= 0 then
          s = s .. tostring(dice_x) .. "d" .. tostring(dice_y)
@@ -71,10 +73,12 @@ local function item_known_info(item)
       end
    end
 
-   local pv = item:calc("pv") or 0
-   local dv = item:calc("dv") or 0
-   if dv ~= 0 or pv ~= 0 then
-      s = s .. " [" .. dv .. "," .. pv .. "]"
+   if equip then
+      local pv = equip:calc(item, "pv") or 0
+      local dv = equip:calc(item, "dv") or 0
+      if dv ~= 0 or pv ~= 0 then
+         s = s .. " [" .. dv .. "," .. pv .. "]"
+      end
    end
 
    return s

--- a/src/mod/elona/api/aspect/IItemEquipment.lua
+++ b/src/mod/elona/api/aspect/IItemEquipment.lua
@@ -1,0 +1,14 @@
+local IAspect = require("api.IAspect")
+
+local IItemEquipment = class.interface("IItemEquipment", {
+                                          dv = "number",
+                                          pv = "number",
+                                          hit_bonus = "number",
+                                          damage_bonus = "number",
+                                          equip_slots = "table",
+                                          pcc_part = { type = "number", optional = true },
+                                                         }, { IAspect })
+
+IItemEquipment.default_impl = "mod.elona.api.aspect.ItemEquipmentAspect"
+
+return IItemEquipment

--- a/src/mod/elona/api/aspect/ItemEquipmentAspect.lua
+++ b/src/mod/elona/api/aspect/ItemEquipmentAspect.lua
@@ -1,0 +1,14 @@
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
+
+local ItemEquipmentAspect = class.class("ItemEquipmentAspect", IItemEquipment)
+
+function ItemEquipmentAspect:init(item, params)
+   self.dv = params.dv or 0
+   self.pv = params.pv or 0
+   self.hit_bonus = params.hit_bonus or 0
+   self.damage_bonus = params.damage_bonus or 0
+   self.equip_slots = params.equip_slots or {}
+   self.pcc_part = params.pcc_part or nil
+end
+
+return ItemEquipmentAspect

--- a/src/mod/elona/data/item/equip/ammo.lua
+++ b/src/mod/elona/data/item/equip/ammo.lua
@@ -1,3 +1,5 @@
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
+
 --
 -- Arrow
 --
@@ -11,12 +13,7 @@ data:add {
    weight = 1200,
    dice_x = 1,
    dice_y = 8,
-   hit_bonus = 2,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 25000,
-   equip_slots = { "elona.ammo" },
-   subcategory = 25001,
    coefficient = 100,
 
    skill = "elona.bow",
@@ -24,6 +21,14 @@ data:add {
    categories = {
       "elona.equip_ammo",
       "elona.equip_ammo_arrow"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ammo" },
+         hit_bonus = 2,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -40,12 +45,7 @@ data:add {
    weight = 3500,
    dice_x = 1,
    dice_y = 8,
-   hit_bonus = 2,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 25000,
-   equip_slots = { "elona.ammo" },
-   subcategory = 25002,
    coefficient = 100,
 
    skill = "elona.crossbow",
@@ -53,6 +53,14 @@ data:add {
    categories = {
       "elona.equip_ammo",
       "elona.equip_ammo_bolt"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ammo" },
+         hit_bonus = 2,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -69,12 +77,7 @@ data:add {
    weight = 2400,
    dice_x = 2,
    dice_y = 2,
-   hit_bonus = 4,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 25000,
-   equip_slots = { "elona.ammo" },
-   subcategory = 25020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -85,6 +88,14 @@ data:add {
       "elona.equip_ammo",
       "elona.equip_ammo_bullet",
       "elona.tag_sf"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ammo" },
+         hit_bonus = 4,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -101,11 +112,7 @@ data:add {
    weight = 800,
    dice_x = 2,
    dice_y = 3,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 25000,
-   equip_slots = { "elona.ammo" },
-   subcategory = 25030,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -116,5 +123,12 @@ data:add {
       "elona.equip_ammo",
       "elona.equip_ammo_energy_cell",
       "elona.tag_sf"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ammo" },
+         damage_bonus = 1,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/arm.lua
+++ b/src/mod/elona/data/item/equip/arm.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Heavy Glove
@@ -12,19 +13,21 @@ data:add {
    image = "elona.item_thick_gauntlets",
    value = 400,
    weight = 1100,
-   hit_bonus = 2,
-   damage_bonus = 1,
-   pv = 4,
-   dv = 2,
    material = "elona.metal",
-   appearance = 2,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22001,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_gauntlet",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 2,
+         pv = 4,
+         hit_bonus = 2,
+         damage_bonus = 1,
+         pcc_part = 2
+      }
    }
 }
 
@@ -35,20 +38,22 @@ data:add {
    image = "elona.item_plate_gauntlets",
    value = 1800,
    weight = 1800,
-   hit_bonus = 3,
-   damage_bonus = 3,
-   pv = 7,
-   dv = 3,
    material = "elona.metal",
-   appearance = 2,
    level = 30,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22001,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_gauntlet",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 3,
+         pv = 7,
+         hit_bonus = 3,
+         damage_bonus = 3,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -59,20 +64,22 @@ data:add {
    image = "elona.item_composite_gauntlets",
    value = 950,
    weight = 1300,
-   hit_bonus = 4,
-   damage_bonus = 2,
-   pv = 5,
-   dv = 3,
    material = "elona.metal",
-   appearance = 2,
    level = 15,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22001,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_gauntlet",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 3,
+         pv = 5,
+         hit_bonus = 4,
+         damage_bonus = 2,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -87,20 +94,22 @@ data:add {
    image = "elona.item_decorated_gloves",
    value = 1400,
    weight = 700,
-   hit_bonus = 6,
-   damage_bonus = 2,
-   pv = 5,
-   dv = 7,
    material = "elona.soft",
-   appearance = 1,
    level = 30,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22003,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_glove",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         hit_bonus = 6,
+         damage_bonus = 2,
+         dv = 7,
+         pv = 5,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -111,14 +120,9 @@ data:add {
    image = "elona.item_plate_gauntlets",
    value = 40000,
    weight = 1200,
-   pv = 30,
-   dv = 5,
    material = "elona.mithril",
    level = 20,
    fltselect = 3,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22003,
    coefficient = 100,
 
    is_precious = true,
@@ -143,6 +147,14 @@ data:add {
       { _id = "elona.modify_skill", power = 450, params = { skill_id = "elona.dual_wield" } },
       { _id = "elona.modify_attribute", power = 500, params = { skill_id = "elona.stat_luck" } },
       { _id = "elona.res_confuse", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 5,
+         pv = 30,
+      }
    }
 }
 
@@ -153,20 +165,22 @@ data:add {
    image = "elona.item_gloves",
    value = 800,
    weight = 450,
-   hit_bonus = 5,
-   damage_bonus = 1,
-   pv = 4,
-   dv = 5,
    material = "elona.soft",
-   appearance = 1,
    level = 15,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22003,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_glove",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 5,
+         pv = 4,
+         hit_bonus = 5,
+         damage_bonus = 1,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -177,17 +191,19 @@ data:add {
    image = "elona.item_light_gloves",
    value = 280,
    weight = 200,
-   hit_bonus = 3,
-   pv = 3,
-   dv = 3,
    material = "elona.soft",
-   appearance = 1,
-   category = 22000,
-   equip_slots = { "elona.arm" },
-   subcategory = 22003,
    coefficient = 100,
    categories = {
       "elona.equip_wrist_glove",
       "elona.equip_wrist"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.arm" },
+         dv = 3,
+         pv = 3,
+         hit_bonus = 3,
+         pcc_part = 1,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/body.lua
+++ b/src/mod/elona/data/item/equip/body.lua
@@ -1,3 +1,5 @@
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
+
 --
 -- Heavy Armor
 --
@@ -9,17 +11,19 @@ data:add {
    image = "elona.item_breastplate",
    value = 600,
    weight = 4500,
-   pv = 10,
-   dv = 6,
    material = "elona.metal",
-   appearance = 1,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 6,
+         pv = 10,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -30,18 +34,20 @@ data:add {
    image = "elona.item_banded_mail",
    value = 1500,
    weight = 6500,
-   pv = 12,
-   dv = 5,
    material = "elona.metal",
-   appearance = 2,
    level = 10,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 5,
+         pv = 12,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -52,18 +58,20 @@ data:add {
    image = "elona.item_plate_mail",
    value = 12500,
    weight = 7500,
-   pv = 21,
-   dv = 6,
    material = "elona.metal",
-   appearance = 7,
    level = 50,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 6,
+         pv = 21,
+         pcc_part = 7,
+      }
    }
 }
 
@@ -74,18 +82,20 @@ data:add {
    image = "elona.item_ring_mail",
    value = 2400,
    weight = 5000,
-   pv = 14,
-   dv = 6,
    material = "elona.metal",
-   appearance = 2,
    level = 20,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 6,
+         pv = 14,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -96,18 +106,20 @@ data:add {
    image = "elona.item_composite_mail",
    value = 4500,
    weight = 5500,
-   pv = 17,
-   dv = 7,
    material = "elona.metal",
-   appearance = 6,
    level = 30,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 7,
+         pv = 17,
+         pcc_part = 6,
+      }
    }
 }
 
@@ -118,18 +130,20 @@ data:add {
    image = "elona.item_chain_mail",
    value = 8000,
    weight = 5200,
-   pv = 19,
-   dv = 7,
    material = "elona.metal",
-   appearance = 6,
    level = 40,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16001,
    coefficient = 100,
    categories = {
       "elona.equip_body_mail",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 7,
+         pv = 19,
+         pcc_part = 6,
+      }
    }
 }
 
@@ -144,17 +158,19 @@ data:add {
    image = "elona.item_robe",
    value = 450,
    weight = 800,
-   pv = 3,
-   dv = 11,
    material = "elona.soft",
-   appearance = 3,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 11,
+         pv = 3,
+         pcc_part = 3,
+      }
    }
 }
 
@@ -165,18 +181,20 @@ data:add {
    image = "elona.item_pope_robe",
    value = 9500,
    weight = 1200,
-   pv = 8,
-   dv = 18,
    material = "elona.soft",
-   appearance = 4,
    level = 45,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 18,
+         pv = 8,
+         pcc_part = 4,
+      }
    }
 }
 
@@ -187,18 +205,20 @@ data:add {
    image = "elona.item_light_mail",
    value = 1200,
    weight = 1800,
-   pv = 8,
-   dv = 10,
    material = "elona.soft",
-   appearance = 2,
    level = 10,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 10,
+         pv = 8,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -209,18 +229,20 @@ data:add {
    image = "elona.item_coat",
    value = 2000,
    weight = 1500,
-   pv = 9,
-   dv = 13,
    material = "elona.soft",
-   appearance = 5,
    level = 20,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 13,
+         pv = 9,
+         pcc_part = 5,
+      }
    }
 }
 
@@ -231,18 +253,20 @@ data:add {
    image = "elona.item_breast_plate",
    value = 5500,
    weight = 2800,
-   pv = 11,
-   dv = 15,
    material = "elona.soft",
-   appearance = 2,
    level = 25,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 15,
+         pv = 11,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -253,17 +277,19 @@ data:add {
    image = "elona.item_bulletproof_jacket",
    value = 7200,
    weight = 1600,
-   pv = 15,
-   dv = 14,
    material = "elona.soft",
-   appearance = 5,
    level = 35,
-   category = 16000,
-   equip_slots = { "elona.body" },
-   subcategory = 16003,
    coefficient = 100,
    categories = {
       "elona.equip_body_robe",
       "elona.equip_body"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.body" },
+         dv = 14,
+         pv = 15,
+         pcc_part = 5,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/cloak.lua
+++ b/src/mod/elona/data/item/equip/cloak.lua
@@ -1,5 +1,6 @@
 local Calc = require("mod.elona.api.Calc")
 local Enum = require("api.Enum")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Cloak
@@ -12,17 +13,19 @@ data:add {
    image = "elona.item_light_cloak",
    value = 250,
    weight = 700,
-   pv = 3,
-   dv = 4,
    material = "elona.soft",
-   appearance = 1,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    coefficient = 100,
    categories = {
       "elona.equip_back",
       "elona.equip_back_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 4,
+         pv = 3,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -33,18 +36,20 @@ data:add {
    image = "elona.item_armored_cloak",
    value = 1400,
    weight = 1800,
-   pv = 4,
-   dv = 5,
    material = "elona.soft",
-   appearance = 2,
    level = 15,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    coefficient = 100,
    categories = {
       "elona.equip_back",
       "elona.equip_back_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 5,
+         pv = 4,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -55,18 +60,20 @@ data:add {
    image = "elona.item_cloak",
    value = 3500,
    weight = 1500,
-   pv = 3,
-   dv = 7,
    material = "elona.soft",
-   appearance = 1,
    level = 30,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    coefficient = 100,
    categories = {
       "elona.equip_back",
       "elona.equip_back_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 7,
+         pv = 3,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -77,13 +84,8 @@ data:add {
    image = "elona.item_wing",
    value = 4500,
    weight = 500,
-   dv = 9,
    material = "elona.soft",
-   appearance = 3,
    level = 10,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    rarity = 500000,
    coefficient = 100,
 
@@ -94,6 +96,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.float", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 9,
+         pcc_part = 3,
+      }
    }
 }
 
@@ -104,14 +114,8 @@ data:add {
    image = "elona.item_feather",
    value = 18000,
    weight = 500,
-   pv = 6,
-   dv = 4,
    material = "elona.metal",
-   appearance = 4,
    level = 25,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    rarity = 100000,
    coefficient = 100,
 
@@ -122,6 +126,15 @@ data:add {
 
    enchantments = {
       { _id = "elona.float", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 4,
+         pv = 6,
+         pcc_part = 4,
+      }
    }
 }
 
@@ -132,14 +145,8 @@ data:add {
    image = "elona.item_light_cloak",
    value = 18000,
    weight = 400,
-   pv = 3,
-   dv = 7,
    material = "elona.soft",
-   appearance = 1,
    level = 25,
-   category = 20000,
-   equip_slots = { "elona.back" },
-   subcategory = 20001,
    rarity = 10000,
    coefficient = 100,
 
@@ -157,5 +164,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.res_etherwind", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.back" },
+         dv = 7,
+         pv = 3,
+         pcc_part = 1,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/girdle.lua
+++ b/src/mod/elona/data/item/equip/girdle.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Girdle
@@ -12,17 +13,19 @@ data:add {
    image = "elona.item_girdle",
    value = 300,
    weight = 900,
-   pv = 3,
-   dv = 3,
    material = "elona.soft",
-   appearance = 1,
-   category = 19000,
-   equip_slots = { "elona.waist" },
-   subcategory = 19001,
    coefficient = 100,
    categories = {
       "elona.equip_back_girdle",
       "elona.equip_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.waist" },
+         dv = 3,
+         pv = 3,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -33,18 +36,20 @@ data:add {
    image = "elona.item_composite_girdle",
    value = 2400,
    weight = 650,
-   pv = 3,
-   dv = 5,
    material = "elona.metal",
-   appearance = 3,
    level = 15,
-   category = 19000,
-   equip_slots = { "elona.waist" },
-   subcategory = 19001,
    coefficient = 100,
    categories = {
       "elona.equip_back_girdle",
       "elona.equip_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.waist" },
+         dv = 5,
+         pv = 3,
+         pcc_part = 3,
+      }
    }
 }
 
@@ -55,18 +60,20 @@ data:add {
    image = "elona.item_composite_girdle",
    value = 3900,
    weight = 1400,
-   pv = 6,
-   dv = 3,
    material = "elona.metal",
-   appearance = 2,
    level = 30,
-   category = 19000,
-   equip_slots = { "elona.waist" },
-   subcategory = 19001,
    coefficient = 100,
    categories = {
       "elona.equip_back_girdle",
       "elona.equip_cloak"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.waist" },
+         dv = 3,
+         pv = 6,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -77,15 +84,9 @@ data:add {
    image = "elona.item_composite_girdle",
    value = 15000,
    weight = 1250,
-   pv = 15,
-   dv = 2,
    material = "elona.mithril",
-   appearance = 2,
    level = 13,
    fltselect = 3,
-   category = 19000,
-   equip_slots = { "elona.waist" },
-   subcategory = 19001,
    coefficient = 100,
 
    is_precious = true,
@@ -106,5 +107,14 @@ data:add {
       { _id = "elona.cure_bleeding", power = 100 },
       { _id = "elona.modify_resistance", power = 450, params = { element_id = "elona.nether" } },
       { _id = "elona.modify_resistance", power = 350, params = { element_id = "elona.fire" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.waist" },
+         dv = 2,
+         pv = 15,
+         pcc_part = 2,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/head.lua
+++ b/src/mod/elona/data/item/equip/head.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Heavy Helm
@@ -12,17 +13,19 @@ data:add {
    image = "elona.item_heavy_helm",
    value = 4800,
    weight = 2400,
-   pv = 7,
-   dv = 4,
    material = "elona.metal",
    level = 30,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
    categories = {
       "elona.equip_head_helm",
       "elona.equip_head"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 4,
+         pv = 7,
+      }
    }
 }
 
@@ -33,17 +36,19 @@ data:add {
    image = "elona.item_knight_helm",
    value = 2200,
    weight = 2000,
-   pv = 7,
-   dv = 1,
    material = "elona.metal",
    level = 15,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
    categories = {
       "elona.equip_head_helm",
       "elona.equip_head"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 1,
+         pv = 7,
+      }
    }
 }
 
@@ -54,16 +59,18 @@ data:add {
    image = "elona.item_helm",
    value = 600,
    weight = 1600,
-   pv = 5,
-   dv = 3,
    material = "elona.metal",
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
    categories = {
       "elona.equip_head_helm",
       "elona.equip_head"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 3,
+         pv = 5,
+      }
    }
 }
 
@@ -74,17 +81,19 @@ data:add {
    image = "elona.item_composite_helm",
    value = 9600,
    weight = 1800,
-   pv = 8,
-   dv = 5,
    material = "elona.metal",
    level = 60,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
    categories = {
       "elona.equip_head_helm",
       "elona.equip_head"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 5,
+         pv = 8,
+      }
    }
 }
 
@@ -95,14 +104,9 @@ data:add {
    image = "elona.item_knight_helm",
    value = 40000,
    weight = 1500,
-   pv = 15,
-   dv = 4,
    material = "elona.mithril",
    level = 20,
    fltselect = 3,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
 
    is_precious = true,
@@ -128,6 +132,14 @@ data:add {
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.mind" } },
       { _id = "elona.modify_resistance", power = 150, params = { element_id = "elona.magic" } },
       { _id = "elona.modify_skill", power = 300, params = { skill_id = "elona.anatomy" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 4,
+         pv = 15,
+      }
    }
 }
 
@@ -139,14 +151,9 @@ data:add {
    value = 15000,
    weight = 2400,
    damage_bonus = 8,
-   pv = 7,
-   dv = 2,
    material = "elona.obsidian",
    level = 5,
    fltselect = 3,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12001,
    coefficient = 100,
 
    is_precious = true,
@@ -169,6 +176,14 @@ data:add {
       { _id = "elona.extra_shoot", power = 150 },
       { _id = "elona.damage_reflection", power = 180 },
       { _id = "elona.res_mutation", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 2,
+         pv = 7,
+      }
    }
 }
 
@@ -183,17 +198,19 @@ data:add {
    image = "elona.item_magic_hat",
    value = 1400,
    weight = 600,
-   pv = 4,
-   dv = 6,
    material = "elona.soft",
    level = 15,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12002,
    coefficient = 100,
    categories = {
       "elona.equip_head_hat",
       "elona.equip_head"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 6,
+         pv = 4,
+      }
    }
 }
 
@@ -204,13 +221,8 @@ data:add {
    image = "elona.item_fairy_hat",
    value = 7200,
    weight = 400,
-   pv = 5,
-   dv = 7,
    material = "elona.soft",
    level = 30,
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12002,
    coefficient = 100,
 
    categories = {
@@ -220,6 +232,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.res_mutation", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 7,
+         pv = 5,
+      }
    }
 }
 
@@ -230,15 +250,18 @@ data:add {
    image = "elona.item_feather_hat",
    value = 400,
    weight = 500,
-   pv = 1,
-   dv = 5,
    material = "elona.soft",
-   category = 12000,
-   equip_slots = { "elona.head" },
-   subcategory = 12002,
    coefficient = 100,
    categories = {
       "elona.equip_head_hat",
       "elona.equip_head"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.head" },
+         dv = 5,
+         pv = 1,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/leg.lua
+++ b/src/mod/elona/data/item/equip/leg.lua
@@ -1,6 +1,7 @@
 local Calc = require("mod.elona.api.Calc")
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Heavy Boots
@@ -13,17 +14,20 @@ data:add {
    image = "elona.item_heavy_boots",
    value = 480,
    weight = 950,
-   pv = 3,
-   dv = 1,
    material = "elona.metal",
-   appearance = 3,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18001,
    coefficient = 100,
    categories = {
       "elona.equip_leg_heavy_boots",
       "elona.equip_leg"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 1,
+         pv = 3,
+         pcc_part = 3,
+      }
    }
 }
 
@@ -34,18 +38,21 @@ data:add {
    image = "elona.item_composite_boots",
    value = 2200,
    weight = 720,
-   pv = 5,
-   dv = 1,
    material = "elona.metal",
-   appearance = 4,
    level = 15,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18001,
    coefficient = 100,
    categories = {
       "elona.equip_leg_heavy_boots",
       "elona.equip_leg"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 1,
+         pv = 5,
+         pcc_part = 4,
+      }
    }
 }
 
@@ -56,17 +63,19 @@ data:add {
    image = "elona.item_armored_boots",
    value = 4800,
    weight = 1400,
-   pv = 6,
    material = "elona.metal",
-   appearance = 4,
    level = 30,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18001,
    coefficient = 100,
    categories = {
       "elona.equip_leg_heavy_boots",
       "elona.equip_leg"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         pv = 6,
+         pcc_part = 4,
+      }
    }
 }
 
@@ -81,17 +90,19 @@ data:add {
    image = "elona.item_boots",
    value = 260,
    weight = 250,
-   pv = 1,
-   dv = 3,
    material = "elona.soft",
-   appearance = 5,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18002,
    coefficient = 100,
    categories = {
       "elona.equip_leg_shoes",
       "elona.equip_leg"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 3,
+         pv = 1,
+         pcc_part = 5,
+      }
    }
 }
 
@@ -102,18 +113,20 @@ data:add {
    image = "elona.item_boots",
    value = 1500,
    weight = 450,
-   pv = 2,
-   dv = 5,
    material = "elona.soft",
-   appearance = 1,
    level = 15,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18002,
    coefficient = 100,
    categories = {
       "elona.equip_leg_shoes",
       "elona.equip_leg"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 5,
+         pv = 2,
+         pcc_part = 1,
+      }
    }
 }
 
@@ -124,18 +137,20 @@ data:add {
    image = "elona.item_tight_boots",
    value = 3500,
    weight = 650,
-   pv = 3,
-   dv = 6,
    material = "elona.soft",
-   appearance = 2,
    level = 30,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18002,
    coefficient = 100,
    categories = {
       "elona.equip_leg_shoes",
       "elona.equip_leg"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 6,
+         pv = 3,
+         pcc_part = 2,
+      }
    }
 }
 
@@ -146,14 +161,8 @@ data:add {
    image = "elona.item_composite_boots",
    value = 24000,
    weight = 300,
-   pv = 2,
-   dv = 7,
    material = "elona.soft",
-   appearance = 3,
    level = 30,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18002,
    rarity = 25000,
    coefficient = 100,
 
@@ -171,6 +180,15 @@ data:add {
 
    enchantments = {
       { _id = "elona.fast_travel", power = 500 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 7,
+         pv = 2,
+         pcc_part = 3,
+      }
    }
 }
 
@@ -181,15 +199,9 @@ data:add {
    image = "elona.item_tight_boots",
    value = 25000,
    weight = 650,
-   pv = 7,
-   dv = 16,
    material = "elona.leather",
-   appearance = 2,
    level = 15,
    fltselect = 3,
-   category = 18000,
-   equip_slots = { "elona.leg" },
-   subcategory = 18002,
    coefficient = 100,
 
    is_precious = true,
@@ -211,5 +223,14 @@ data:add {
       { _id = "elona.fast_travel", power = 100 },
       { _id = "elona.modify_attribute", power = 250, params = { skill_id = "elona.stat_dexterity" } },
       { _id = "elona.modify_skill", power = 200, params = { skill_id = "elona.traveling" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.leg" },
+         dv = 16,
+         pv = 7,
+         pcc_part = 2,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/melee.lua
+++ b/src/mod/elona/data/item/equip/melee.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Broadsword
@@ -14,12 +15,7 @@ data:add {
    weight = 4000,
    dice_x = 3,
    dice_y = 7,
-   hit_bonus = 1,
-   damage_bonus = 8,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10001,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -27,6 +23,14 @@ data:add {
    categories = {
       "elona.equip_melee_broadsword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 1,
+         damage_bonus = 8,
+      }
    }
 }
 
@@ -39,14 +43,9 @@ data:add {
    weight = 6500,
    dice_x = 3,
    dice_y = 14,
-   hit_bonus = 1,
-   damage_bonus = 16,
    material = "elona.silver",
    level = 45,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10001,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -66,6 +65,14 @@ data:add {
       { _id = "elona.crit", power = 250 },
       { _id = "elona.pierce", power = 200 },
       { _id = "elona.res_mutation", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 1,
+         damage_bonus = 16,
+      }
    }
 }
 
@@ -78,16 +85,9 @@ data:add {
    weight = 22500,
    dice_x = 3,
    dice_y = 14,
-   hit_bonus = -25,
-   damage_bonus = 20,
-   pv = 30,
-   dv = -42,
    material = "elona.iron",
    level = 55,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10001,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -105,6 +105,16 @@ data:add {
    enchantments = {
       { _id = "elona.dragon_bane", power = 300 },
       { _id = "elona.god_bane", power = 200 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -25,
+         damage_bonus = 20,
+         pv = 30,
+         dv = -42,
+      }
    }
 }
 
@@ -121,12 +131,7 @@ data:add {
    weight = 1500,
    dice_x = 2,
    dice_y = 8,
-   hit_bonus = 5,
-   damage_bonus = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -134,6 +139,14 @@ data:add {
    categories = {
       "elona.equip_melee_long_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 5,
+         damage_bonus = 4,
+      }
    }
 }
 
@@ -146,16 +159,9 @@ data:add {
    weight = 2200,
    dice_x = 4,
    dice_y = 8,
-   hit_bonus = 2,
-   damage_bonus = 8,
-   pv = 2,
-   dv = -3,
    material = "elona.steel",
    level = 40,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -180,6 +186,16 @@ data:add {
       { _id = "elona.elemental_damage", power = 400, params = { element_id = "elona.nerve" } },
       { _id = "elona.modify_attribute", power = 300, params = { skill_id = "elona.stat_speed" } },
       { _id = "elona.res_paralyze", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 2,
+         damage_bonus = 8,
+         dv = -3,
+         pv = 2,
+      }
    }
 }
 
@@ -192,13 +208,9 @@ data:add {
    weight = 1400,
    dice_x = 7,
    dice_y = 7,
-   hit_bonus = 4,
    material = "elona.silver",
    level = 30,
    fltselect = 2,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -222,6 +234,13 @@ data:add {
       { _id = "elona.res_confuse", power = 100 },
       { _id = "elona.modify_attribute", power = 300, params = { skill_id = "elona.stat_strength" } },
       { _id = "elona.modify_resistance", power = 200, params = { element_id = "elona.nerve" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 4,
+      }
    }
 }
 
@@ -234,16 +253,9 @@ data:add {
    weight = 4000,
    dice_x = 3,
    dice_y = 13,
-   hit_bonus = 8,
-   damage_bonus = 5,
-   pv = 4,
-   dv = -4,
    material = "elona.obsidian",
    level = 50,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -269,6 +281,16 @@ data:add {
       { _id = "elona.modify_skill", power = 300, params = { skill_id = "elona.dual_wield" } },
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.chaos" } },
       { _id = "elona.modify_resistance", power = 200, params = { element_id = "elona.nether" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 8,
+         damage_bonus = 5,
+         dv = -4,
+         pv = 4,
+      }
    }
 }
 
@@ -281,16 +303,9 @@ data:add {
    weight = 4200,
    dice_x = 2,
    dice_y = 18,
-   hit_bonus = 4,
-   damage_bonus = 3,
-   pv = 1,
-   dv = -1,
    material = "elona.obsidian",
    level = 30,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -310,6 +325,16 @@ data:add {
 
    enchantments = {
       { _id = "elona.ragnarok", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 4,
+         damage_bonus = 3,
+         dv = -1,
+         pv = 1,
+      }
    }
 }
 
@@ -322,11 +347,7 @@ data:add {
    weight = 1200,
    dice_x = 4,
    dice_y = 4,
-   damage_bonus = 6,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -334,6 +355,13 @@ data:add {
    categories = {
       "elona.equip_melee_long_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         damage_bonus = 6,
+      }
    }
 }
 
@@ -346,14 +374,9 @@ data:add {
    weight = 2500,
    dice_x = 6,
    dice_y = 6,
-   hit_bonus = 3,
-   damage_bonus = 2,
    material = "elona.obsidian",
    level = 25,
    fltselect = 2,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    coefficient = 100,
 
    skill = "elona.long_sword",
@@ -377,6 +400,14 @@ data:add {
       { _id = "elona.elemental_damage", power = 400, params = { element_id = "elona.lightning" } },
       { _id = "elona.dragon_bane", power = 1150 },
       { _id = "elona.modify_attribute", power = 720, params = { skill_id = "elona.stat_constitution" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 3,
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -390,9 +421,6 @@ data:add {
    dice_x = 2,
    dice_y = 5,
    material = "elona.ether",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10002,
    rarity = 2000,
    coefficient = 100,
    random_color = "Furniture",
@@ -403,7 +431,13 @@ data:add {
       "elona.equip_melee_long_sword",
       "elona.equip_melee"
    },
-   light = light.item
+   light = light.item,
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+      }
+   }
 }
 
 --
@@ -419,13 +453,7 @@ data:add {
    weight = 600,
    dice_x = 2,
    dice_y = 5,
-   hit_bonus = 9,
-   damage_bonus = 4,
-   dv = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    coefficient = 100,
 
    skill = "elona.short_sword",
@@ -433,6 +461,15 @@ data:add {
    categories = {
       "elona.equip_melee_short_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 9,
+         damage_bonus = 4,
+         dv = 4,
+      }
    }
 }
 
@@ -445,16 +482,9 @@ data:add {
    weight = 600,
    dice_x = 5,
    dice_y = 5,
-   hit_bonus = 16,
-   damage_bonus = 8,
-   pv = 6,
-   dv = 4,
    material = "elona.ether",
    level = 40,
    fltselect = 2,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    coefficient = 100,
 
    skill = "elona.short_sword",
@@ -477,6 +507,16 @@ data:add {
       { _id = "elona.elemental_damage", power = 300, params = { element_id = "elona.lightning" } },
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.lightning" } },
       { _id = "elona.modify_skill", power = 350, params = { skill_id = "elona.casting" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 16,
+         damage_bonus = 8,
+         dv = 4,
+         pv = 6,
+      }
    }
 }
 
@@ -489,13 +529,7 @@ data:add {
    weight = 900,
    dice_x = 3,
    dice_y = 4,
-   hit_bonus = 7,
-   damage_bonus = 3,
-   dv = 2,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    coefficient = 100,
 
    skill = "elona.short_sword",
@@ -503,6 +537,15 @@ data:add {
    categories = {
       "elona.equip_melee_short_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 7,
+         damage_bonus = 3,
+         dv = 2,
+      }
    }
 }
 
@@ -515,13 +558,7 @@ data:add {
    weight = 700,
    dice_x = 4,
    dice_y = 4,
-   hit_bonus = 6,
-   damage_bonus = 5,
-   dv = 1,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    coefficient = 100,
 
    skill = "elona.short_sword",
@@ -529,6 +566,15 @@ data:add {
    categories = {
       "elona.equip_melee_short_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 6,
+         damage_bonus = 5,
+         dv = 1,
+      }
    }
 }
 
@@ -541,16 +587,9 @@ data:add {
    weight = 400,
    dice_x = 4,
    dice_y = 6,
-   hit_bonus = 13,
-   damage_bonus = 18,
-   pv = 13,
-   dv = 18,
    material = "elona.mica",
    level = 60,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    coefficient = 100,
 
    skill = "elona.short_sword",
@@ -575,6 +614,16 @@ data:add {
       { _id = "elona.modify_attribute", power = 1500, params = { skill_id = "elona.stat_luck" } },
       { _id = "elona.absorb_stamina", power = 400 },
       { _id = "elona.modify_skill", power = 600, params = { skill_id = "elona.fishing" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         dv = 18,
+         pv = 13,
+         hit_bonus = 13,
+         damage_bonus = 18,
+      }
    }
 }
 
@@ -587,12 +636,7 @@ data:add {
    weight = 400,
    dice_x = 1,
    dice_y = 14,
-   hit_bonus = 5,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10003,
    rarity = 50000,
    coefficient = 100,
 
@@ -601,6 +645,14 @@ data:add {
    categories = {
       "elona.equip_melee_short_sword",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 5,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -617,12 +669,7 @@ data:add {
    weight = 1000,
    dice_x = 3,
    dice_y = 4,
-   hit_bonus = 4,
-   damage_bonus = 7,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10004,
    coefficient = 100,
 
    skill = "elona.blunt",
@@ -630,6 +677,14 @@ data:add {
    categories = {
       "elona.equip_melee_club",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 4,
+         damage_bonus = 7,
+      }
    }
 }
 
@@ -642,14 +697,9 @@ data:add {
    weight = 1800,
    dice_x = 3,
    dice_y = 5,
-   hit_bonus = 8,
-   damage_bonus = 22,
    material = "elona.iron",
    level = 30,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10004,
    coefficient = 100,
 
    skill = "elona.blunt",
@@ -675,6 +725,14 @@ data:add {
       { _id = "elona.elemental_damage", power = 350, params = { element_id = "elona.fire" } },
       { _id = "elona.res_confuse", power = 100 },
       { _id = "elona.res_fear", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 8,
+         damage_bonus = 22,
+      }
    }
 }
 
@@ -691,12 +749,7 @@ data:add {
    weight = 4200,
    dice_x = 2,
    dice_y = 13,
-   hit_bonus = -3,
-   damage_bonus = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10005,
    coefficient = 100,
 
    skill = "elona.blunt",
@@ -704,6 +757,14 @@ data:add {
    categories = {
       "elona.equip_melee_hammer",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -3,
+         damage_bonus = 4,
+      }
    }
 }
 
@@ -716,14 +777,9 @@ data:add {
    weight = 6500,
    dice_x = 2,
    dice_y = 30,
-   hit_bonus = -3,
-   damage_bonus = 2,
    material = "elona.adamantium",
    level = 60,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10005,
    coefficient = 100,
 
    skill = "elona.blunt",
@@ -748,6 +804,14 @@ data:add {
       { _id = "elona.modify_attribute", power = 600, params = { skill_id = "elona.stat_strength" } },
       { _id = "elona.modify_skill", power = 450, params = { skill_id = "elona.two_hand" } },
       { _id = "elona.modify_resistance", power = 400, params = { element_id = "elona.mind" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         damage_bonus = 2,
+         hit_bonus = -3,
+      }
    }
 }
 
@@ -764,13 +828,7 @@ data:add {
    weight = 900,
    dice_x = 1,
    dice_y = 8,
-   hit_bonus = 4,
-   damage_bonus = 3,
-   dv = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10006,
    coefficient = 100,
 
    skill = "elona.stave",
@@ -778,6 +836,15 @@ data:add {
    categories = {
       "elona.equip_melee_staff",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 4,
+         damage_bonus = 3,
+         dv = 4,
+      }
    }
 }
 
@@ -790,13 +857,7 @@ data:add {
    weight = 800,
    dice_x = 2,
    dice_y = 5,
-   hit_bonus = 3,
-   damage_bonus = 4,
-   dv = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10006,
    coefficient = 100,
 
    skill = "elona.stave",
@@ -804,6 +865,15 @@ data:add {
    categories = {
       "elona.equip_melee_staff",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 3,
+         damage_bonus = 4,
+         dv = 4,
+      }
    }
 }
 
@@ -816,16 +886,9 @@ data:add {
    weight = 2500,
    dice_x = 1,
    dice_y = 8,
-   hit_bonus = -5,
-   damage_bonus = 2,
-   pv = 3,
-   dv = 15,
    material = "elona.obsidian",
    level = 35,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10006,
    coefficient = 100,
 
    skill = "elona.stave",
@@ -847,6 +910,16 @@ data:add {
       { _id = "elona.modify_attribute", power = 450, params = { skill_id = "elona.stat_magic" } },
       { _id = "elona.power_magic", power = 350 },
       { _id = "elona.modify_skill", power = 420, params = { skill_id = "elona.casting" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         dv = 15,
+         pv = 3,
+         hit_bonus = -5,
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -859,16 +932,9 @@ data:add {
    weight = 900,
    dice_x = 1,
    dice_y = 14,
-   hit_bonus = 6,
-   damage_bonus = 2,
-   pv = 4,
-   dv = 11,
    material = "elona.obsidian",
    level = 60,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10006,
    coefficient = 100,
 
    skill = "elona.stave",
@@ -895,6 +961,16 @@ data:add {
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.fire" } },
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.cold" } },
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.lightning" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         dv = 11,
+         pv = 4,
+         hit_bonus = 6,
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -911,13 +987,7 @@ data:add {
    weight = 2500,
    dice_x = 3,
    dice_y = 5,
-   hit_bonus = 2,
-   damage_bonus = 4,
-   dv = 3,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10007,
    coefficient = 100,
 
    skill = "elona.polearm",
@@ -925,6 +995,15 @@ data:add {
    categories = {
       "elona.equip_melee_lance",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 2,
+         damage_bonus = 4,
+         dv = 3,
+      }
    }
 }
 
@@ -937,13 +1016,7 @@ data:add {
    weight = 1800,
    dice_x = 4,
    dice_y = 4,
-   hit_bonus = 1,
-   damage_bonus = 3,
-   dv = 3,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10007,
    coefficient = 100,
 
    skill = "elona.polearm",
@@ -951,6 +1024,15 @@ data:add {
    categories = {
       "elona.equip_melee_lance",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 1,
+         damage_bonus = 3,
+         dv = 3,
+      }
    }
 }
 
@@ -963,15 +1045,9 @@ data:add {
    weight = 2000,
    dice_x = 8,
    dice_y = 4,
-   hit_bonus = 2,
-   damage_bonus = 11,
-   dv = 6,
    material = "elona.iron",
    level = 35,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10007,
    coefficient = 100,
 
    skill = "elona.polearm",
@@ -995,6 +1071,15 @@ data:add {
       { _id = "elona.elemental_damage", power = 400, params = { element_id = "elona.nether" } },
       { _id = "elona.modify_resistance", power = 300, params = { element_id = "elona.nether" } },
       { _id = "elona.res_fear", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 2,
+         damage_bonus = 11,
+         dv = 6,
+      }
    }
 }
 
@@ -1007,15 +1092,9 @@ data:add {
    weight = 4400,
    dice_x = 7,
    dice_y = 5,
-   hit_bonus = 12,
-   damage_bonus = 11,
-   dv = 4,
    material = "elona.silver",
    level = 60,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10007,
    coefficient = 100,
 
    skill = "elona.polearm",
@@ -1038,6 +1117,15 @@ data:add {
       { _id = "elona.modify_attribute", power = 650, params = { skill_id = "elona.stat_will" } },
       { _id = "elona.modify_resistance", power = 200, params = { element_id = "elona.darkness" } },
       { _id = "elona.modify_resistance", power = 150, params = { element_id = "elona.nether" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 12,
+         damage_bonus = 11,
+         dv = 4,
+      }
    }
 }
 
@@ -1054,12 +1142,7 @@ data:add {
    weight = 3800,
    dice_x = 2,
    dice_y = 10,
-   hit_bonus = -2,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10008,
    coefficient = 100,
 
    skill = "elona.polearm",
@@ -1067,6 +1150,14 @@ data:add {
    categories = {
       "elona.equip_melee_halberd",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -2,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -1083,12 +1174,7 @@ data:add {
    weight = 900,
    dice_x = 2,
    dice_y = 9,
-   hit_bonus = 4,
-   damage_bonus = 5,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10009,
    coefficient = 100,
 
    skill = "elona.axe",
@@ -1096,6 +1182,14 @@ data:add {
    categories = {
       "elona.equip_melee_hand_axe",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 4,
+         damage_bonus = 5,
+      }
    }
 }
 
@@ -1112,12 +1206,7 @@ data:add {
    weight = 3700,
    dice_x = 1,
    dice_y = 18,
-   hit_bonus = -1,
-   damage_bonus = 3,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10010,
    coefficient = 100,
 
    skill = "elona.axe",
@@ -1125,6 +1214,14 @@ data:add {
    categories = {
       "elona.equip_melee_axe",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -1,
+         damage_bonus = 3,
+      }
    }
 }
 
@@ -1137,12 +1234,7 @@ data:add {
    weight = 3500,
    dice_x = 1,
    dice_y = 20,
-   hit_bonus = -1,
-   damage_bonus = 5,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10010,
    coefficient = 100,
 
    skill = "elona.axe",
@@ -1150,6 +1242,14 @@ data:add {
    categories = {
       "elona.equip_melee_axe",
       "elona.equip_melee"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -1,
+         damage_bonus = 5,
+      }
    }
 }
 
@@ -1162,13 +1262,9 @@ data:add {
    weight = 14000,
    dice_x = 1,
    dice_y = 70,
-   hit_bonus = -35,
    material = "elona.rubynus",
    level = 30,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10010,
    coefficient = 100,
 
    skill = "elona.axe",
@@ -1189,6 +1285,13 @@ data:add {
 
    enchantments = {
       { _id = "elona.crit", power = 750 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -35,
+      }
    }
 }
 
@@ -1205,13 +1308,9 @@ data:add {
    weight = 9000,
    dice_x = 1,
    dice_y = 44,
-   damage_bonus = 4,
    material = "elona.iron",
    level = 35,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10011,
    coefficient = 100,
 
    skill = "elona.scythe",
@@ -1236,6 +1335,13 @@ data:add {
       { _id = "elona.power_magic", power = 450 },
       { _id = "elona.modify_resistance", power = 250, params = { element_id = "elona.magic" } },
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.decapitation" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         damage_bonus = 4,
+      }
    }
 }
 
@@ -1248,12 +1354,7 @@ data:add {
    weight = 1400,
    dice_x = 2,
    dice_y = 5,
-   hit_bonus = 2,
-   damage_bonus = 10,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10011,
    coefficient = 100,
 
    skill = "elona.scythe",
@@ -1266,6 +1367,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.decapitation" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 2,
+         damage_bonus = 10,
+      }
    }
 }
 
@@ -1278,14 +1387,9 @@ data:add {
    weight = 850,
    dice_x = 1,
    dice_y = 38,
-   hit_bonus = 5,
-   damage_bonus = 2,
    material = "elona.spirit_cloth",
    level = 60,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10011,
    coefficient = 100,
 
    skill = "elona.scythe",
@@ -1312,6 +1416,14 @@ data:add {
       { _id = "elona.modify_attribute", power = 550, params = { skill_id = "elona.stat_strength" } },
       { _id = "elona.modify_resistance", power = 400, params = { element_id = "elona.chaos" } },
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.decapitation" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 5,
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -1324,12 +1436,7 @@ data:add {
    weight = 4000,
    dice_x = 1,
    dice_y = 17,
-   hit_bonus = 3,
-   damage_bonus = 4,
    material = "elona.metal",
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10011,
    coefficient = 100,
 
    skill = "elona.scythe",
@@ -1341,6 +1448,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.decapitation" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = 3,
+         damage_bonus = 4,
+      }
    }
 }
 
@@ -1353,14 +1468,9 @@ data:add {
    weight = 376500,
    dice_x = 25,
    dice_y = 16,
-   hit_bonus = -460,
-   damage_bonus = 32,
    material = "elona.ether",
    level = 99,
    fltselect = 3,
-   category = 10000,
-   equip_slots = { "elona.hand" },
-   subcategory = 10011,
    coefficient = 100,
 
    skill = "elona.scythe",
@@ -1383,5 +1493,13 @@ data:add {
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.decapitation" } },
       { _id = "elona.ragnarok", power = 100 },
       { _id = "elona.invoke_skill", power = 350, params = { enchantment_skill_id = "elona.raging_roar" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         hit_bonus = -460,
+         damage_bonus = 32,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/neck.lua
+++ b/src/mod/elona/data/item/equip/neck.lua
@@ -2,6 +2,7 @@ local Gui = require("api.Gui")
 local Skill = require("mod.elona_sys.api.Skill")
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Small Amulet
@@ -16,14 +17,16 @@ data:add {
    value = 200,
    weight = 50,
    material = "elona.soft",
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+      }
    }
 }
 
@@ -35,17 +38,19 @@ data:add {
    image = "elona.item_peridot",
    value = 4400,
    weight = 50,
-   hit_bonus = 4,
    material = "elona.metal",
    level = 30,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = "ring",
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         hit_bonus = 4,
+      }
    }
 }
 
@@ -57,17 +62,19 @@ data:add {
    image = "elona.item_talisman",
    value = 4400,
    weight = 50,
-   dv = 4,
    material = "elona.soft",
    level = 30,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = "ring",
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         dv = 4,
+      }
    }
 }
 
@@ -79,17 +86,19 @@ data:add {
    image = "elona.item_neck_guard",
    value = 2200,
    weight = 50,
-   pv = 3,
    material = "elona.metal",
    level = 10,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = "ring",
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         pv = 3,
+      }
    }
 }
 
@@ -101,12 +110,8 @@ data:add {
    image = "elona.item_charm",
    value = 2000,
    weight = 50,
-   damage_bonus = 3,
    material = "elona.soft",
    level = 10,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = "ring",
    tags = { "fest" },
@@ -114,6 +119,12 @@ data:add {
       "elona.equip_neck_armor",
       "elona.tag_fest",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         damage_bonus = 3,
+      }
    }
 }
 
@@ -127,14 +138,16 @@ data:add {
    weight = 50,
    material = "elona.metal",
    level = 5,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
    has_random_name = "ring",
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+      }
    }
 }
 
@@ -147,15 +160,18 @@ data:add {
    value = 5000,
    weight = 50,
    material = "elona.metal",
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    rarity = 800000,
    coefficient = 100,
    has_random_name = "ring",
    categories = {
       "elona.equip_neck_armor",
       "elona.equip_neck"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+      }
    },
 
    events = {
@@ -200,13 +216,9 @@ data:add {
    image = "elona.item_neck_guard",
    value = 50,
    weight = 250,
-   dv = 8,
    material = "elona.iron",
    level = 15,
    fltselect = 3,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
 
    is_precious = true,
@@ -224,7 +236,14 @@ data:add {
       { _id = "elona.res_pregnancy", power = 100 },
       { _id = "elona.modify_attribute", power = 450, params = { skill_id = "elona.stat_charisma" } },
       { _id = "elona.res_steal", power = 100 },
-   }
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         dv = 8,
+      }
+   },
 }
 
 data:add {
@@ -234,13 +253,9 @@ data:add {
    image = "elona.item_neck_guard",
    value = 9500,
    weight = 400,
-   hit_bonus = 12,
    material = "elona.coral",
    level = 25,
    fltselect = 3,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
 
    is_precious = true,
@@ -260,7 +275,14 @@ data:add {
    enchantments = {
       { _id = "elona.extra_shoot", power = 600 },
       { _id = "elona.modify_skill", power = 700, params = { skill_id = "elona.crossbow" } },
-   }
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         hit_bonus = 12,
+      }
+   },
 }
 
 data:add {
@@ -270,13 +292,9 @@ data:add {
    image = "elona.item_neck_guard",
    value = 9500,
    weight = 400,
-   damage_bonus = 4,
    material = "elona.mica",
    level = 25,
    fltselect = 3,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
 
    is_precious = true,
@@ -296,6 +314,13 @@ data:add {
    enchantments = {
       { _id = "elona.extra_melee", power = 600 },
       { _id = "elona.modify_skill", power = 650, params = { skill_id = "elona.dual_wield" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         damage_bonus = 4,
+      }
    }
 }
 
@@ -306,14 +331,9 @@ data:add {
    image = "elona.item_peridot",
    value = 1200,
    weight = 150,
-   pv = 14,
-   dv = 2,
    material = "elona.mica",
    level = 5,
    fltselect = 3,
-   category = 34000,
-   equip_slots = { "elona.neck" },
-   subcategory = 34001,
    coefficient = 100,
 
    is_precious = true,
@@ -334,5 +354,13 @@ data:add {
       { _id = "elona.god_talk", power = 100 },
       { _id = "elona.modify_skill", power = 550, params = { skill_id = "elona.faith" } },
       { _id = "elona.modify_resistance", power = 400, params = { element_id = "elona.sound" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.neck" },
+         pv = 14,
+         dv = 2,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/ranged.lua
+++ b/src/mod/elona/data/item/equip/ranged.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Bow
@@ -14,12 +15,7 @@ data:add {
    weight = 1200,
    dice_x = 2,
    dice_y = 7,
-   hit_bonus = 4,
-   damage_bonus = 8,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24001,
    coefficient = 100,
 
    skill = "elona.bow",
@@ -31,6 +27,14 @@ data:add {
    categories = {
       "elona.equip_ranged_bow",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 4,
+         damage_bonus = 8,
+      }
    }
 }
 
@@ -43,14 +47,9 @@ data:add {
    weight = 1200,
    dice_x = 2,
    dice_y = 15,
-   hit_bonus = 5,
-   damage_bonus = 7,
    material = "elona.mithril",
    level = 35,
    fltselect = 2,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24001,
    coefficient = 100,
 
    skill = "elona.bow",
@@ -77,6 +76,14 @@ data:add {
       { _id = "elona.modify_attribute", power = 450, params = { skill_id = "elona.stat_dexterity" } },
       { _id = "elona.modify_resistance", power = 300, params = { element_id = "elona.poison" } },
       { _id = "elona.elemental_damage", power = 300, params = { element_id = "elona.poison" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 5,
+         damage_bonus = 7,
+      }
    }
 }
 
@@ -89,12 +96,7 @@ data:add {
    weight = 800,
    dice_x = 3,
    dice_y = 5,
-   hit_bonus = 8,
-   damage_bonus = 3,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24001,
    coefficient = 100,
 
    skill = "elona.bow",
@@ -106,6 +108,14 @@ data:add {
    categories = {
       "elona.equip_ranged_bow",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 8,
+         damage_bonus = 3,
+      }
    }
 }
 
@@ -118,14 +128,9 @@ data:add {
    weight = 800,
    dice_x = 2,
    dice_y = 23,
-   hit_bonus = 4,
-   damage_bonus = 11,
    material = "elona.ether",
    level = 60,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24001,
    coefficient = 100,
 
    skill = "elona.bow",
@@ -151,6 +156,14 @@ data:add {
       { _id = "elona.invoke_skill", power = 200, params = { enchantment_skill_id = "elona.lulwys_trick" } },
       { _id = "elona.modify_attribute", power = 250, params = { skill_id = "elona.stat_speed" } },
       { _id = "elona.modify_resistance", power = 300, params = { element_id = "elona.lightning" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 4,
+         damage_bonus = 11,
+      }
    }
 }
 
@@ -163,13 +176,8 @@ data:add {
    weight = 700,
    dice_x = 1,
    dice_y = 17,
-   hit_bonus = -18,
-   damage_bonus = 10,
    material = "elona.metal",
    level = 15,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24001,
    rarity = 50000,
    coefficient = 100,
 
@@ -182,6 +190,14 @@ data:add {
    categories = {
       "elona.equip_ranged_bow",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = -18,
+         damage_bonus = 10,
+      }
    }
 }
 
@@ -198,12 +214,7 @@ data:add {
    weight = 2800,
    dice_x = 1,
    dice_y = 18,
-   hit_bonus = 4,
-   damage_bonus = 6,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24003,
    coefficient = 100,
 
    skill = "elona.crossbow",
@@ -215,6 +226,14 @@ data:add {
    categories = {
       "elona.equip_ranged_crossbow",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 4,
+         damage_bonus = 6,
+      }
    }
 }
 
@@ -231,12 +250,7 @@ data:add {
    weight = 800,
    dice_x = 1,
    dice_y = 22,
-   hit_bonus = 7,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -249,6 +263,14 @@ data:add {
       "elona.equip_ranged_gun",
       "elona.tag_sf",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 7,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -261,12 +283,7 @@ data:add {
    weight = 1800,
    dice_x = 10,
    dice_y = 3,
-   hit_bonus = 10,
-   damage_bonus = 1,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -279,6 +296,14 @@ data:add {
       "elona.equip_ranged_gun",
       "elona.tag_sf",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 10,
+         damage_bonus = 1,
+      }
    }
 }
 
@@ -291,13 +316,8 @@ data:add {
    weight = 1500,
    dice_x = 4,
    dice_y = 8,
-   hit_bonus = 4,
-   damage_bonus = 6,
    material = "elona.metal",
    level = 10,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -310,6 +330,14 @@ data:add {
       "elona.equip_ranged_gun",
       "elona.tag_sf",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 4,
+         damage_bonus = 6,
+      }
    }
 }
 
@@ -322,14 +350,9 @@ data:add {
    weight = 2800,
    dice_x = 8,
    dice_y = 9,
-   hit_bonus = 7,
-   damage_bonus = 2,
    material = "elona.diamond",
    level = 60,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -355,6 +378,14 @@ data:add {
       { _id = "elona.res_curse", power = 200 },
       { _id = "elona.modify_skill", power = 450, params = { skill_id = "elona.marksman" } },
       { _id = "elona.modify_resistance", power = 350, params = { element_id = "elona.sound" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 7,
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -367,13 +398,8 @@ data:add {
    weight = 950,
    dice_x = 1,
    dice_y = 24,
-   hit_bonus = 14,
-   damage_bonus = 26,
    material = "elona.iron",
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24020,
    coefficient = 100,
 
    skill = "elona.firearm",
@@ -397,6 +423,14 @@ data:add {
 
    enchantments = {
       { _id = "elona.see_invisi", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 14,
+         damage_bonus = 26,
+      }
    }
 }
 
@@ -413,12 +447,7 @@ data:add {
    weight = 1200,
    dice_x = 2,
    dice_y = 12,
-   hit_bonus = 5,
-   damage_bonus = 5,
    material = "elona.metal",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24021,
    rarity = 200000,
    coefficient = 100,
 
@@ -432,6 +461,14 @@ data:add {
       "elona.equip_ranged_laser_gun",
       "elona.tag_sf",
       "elona.equip_ranged",
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 5,
+         damage_bonus = 5,
+      }
    }
 }
 
@@ -444,14 +481,9 @@ data:add {
    weight = 8500,
    dice_x = 4,
    dice_y = 10,
-   hit_bonus = -20,
-   damage_bonus = 15,
    material = "elona.ether",
    level = 80,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24021,
    rarity = 200000,
    coefficient = 100,
 
@@ -480,6 +512,14 @@ data:add {
       { _id = "elona.elemental_damage", power = 300, params = { element_id = "elona.nerve" } },
       { _id = "elona.modify_resistance", power = 300, params = { element_id = "elona.sound" } },
       { _id = "elona.modify_resistance", power = 300, params = { element_id = "elona.chaos" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = -20,
+         damage_bonus = 15,
+      }
    }
 }
 
@@ -497,9 +537,6 @@ data:add {
    dice_x = 1,
    dice_y = 12,
    material = "elona.iron",
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    coefficient = 100,
 
    skill = "elona.throwing",
@@ -509,6 +546,12 @@ data:add {
    categories = {
       "elona.equip_ranged_thrown",
       "elona.equip_ranged"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+      }
    }
 }
 
@@ -521,12 +564,8 @@ data:add {
    weight = 400,
    dice_x = 1,
    dice_y = 20,
-   hit_bonus = 4,
    material = "elona.metal",
    level = 5,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    rarity = 200000,
    coefficient = 100,
 
@@ -541,6 +580,13 @@ data:add {
 
    enchantments = {
       { _id = "elona.elemental_damage", power = 100, params = { element_id = "elona.cut" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 4,
+      }
    }
 }
 
@@ -555,9 +601,6 @@ data:add {
    dice_y = 6,
    material = "elona.metal",
    level = 10,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    rarity = 100000,
    coefficient = 100,
 
@@ -572,6 +615,12 @@ data:add {
 
    enchantments = {
       { _id = "elona.invoke_skill", power = 100, params = { enchantment_skill_id = "elona.grenade" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+      }
    }
 }
 
@@ -587,9 +636,6 @@ data:add {
    material = "elona.adamantium",
    level = 15,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    coefficient = 100,
 
    skill = "elona.throwing",
@@ -597,12 +643,21 @@ data:add {
    identify_difficulty = 500,
    quality = Enum.Quality.Unique,
    effective_range = { 60, 100, 70, 20, 20, 20, 20, 20, 20, 20 },
-   pierce_rate = 50,categories = {
+   pierce_rate = 50,
+
+   categories = {
       "elona.equip_ranged_thrown",
       "elona.unique_item",
       "elona.equip_ranged"
    },
-   light = light.item
+
+   light = light.item,
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+      }
+   }
 }
 
 data:add {
@@ -614,13 +669,9 @@ data:add {
    weight = 75000,
    dice_x = 1,
    dice_y = 112,
-   hit_bonus = -28,
    material = "elona.gold",
    level = 25,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    coefficient = 100,
 
    skill = "elona.throwing",
@@ -645,6 +696,13 @@ data:add {
       { _id = "elona.elemental_damage", power = 400, params = { element_id = "elona.chaos" } },
       { _id = "elona.modify_skill", power = -700, params = { skill_id = "elona.performer" } },
       { _id = "elona.crit", power = 450 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = -28,
+      }
    }
 }
 
@@ -659,9 +717,6 @@ data:add {
    dice_y = 35,
    material = "elona.soft",
    level = 5,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    rarity = 10000,
    coefficient = 100,
 
@@ -676,6 +731,12 @@ data:add {
 
    enchantments = {
       { _id = "elona.elemental_damage", power = 800, params = { element_id = "elona.mind" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+      }
    }
 }
 
@@ -688,14 +749,9 @@ data:add {
    weight = 250,
    dice_x = 1,
    dice_y = 47,
-   hit_bonus = 7,
-   damage_bonus = 4,
    material = "elona.silk",
    level = 40,
    fltselect = 3,
-   category = 24000,
-   equip_slots = { "elona.ranged" },
-   subcategory = 24030,
    coefficient = 100,
 
    skill = "elona.throwing",
@@ -722,5 +778,13 @@ data:add {
       { _id = "elona.modify_attribute", power = 450, params = { skill_id = "elona.stat_charisma" } },
       { _id = "elona.res_pregnancy", power = 100 },
       { _id = "elona.res_etherwind", power = 500 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ranged" },
+         hit_bonus = 7,
+         damage_bonus = 4,
+      }
    }
 }

--- a/src/mod/elona/data/item/equip/ring.lua
+++ b/src/mod/elona/data/item/equip/ring.lua
@@ -4,6 +4,7 @@ local Gui = require("api.Gui")
 local Skill = require("mod.elona_sys.api.Skill")
 local Calc = require("mod.elona.api.Calc")
 local Rand = require("api.Rand")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Small Ring
@@ -18,14 +19,16 @@ data:add {
    value = 450,
    weight = 50,
    material = "elona.soft",
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_ring_ring",
       "elona.equip_ring"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+      }
    }
 }
 
@@ -36,13 +39,9 @@ data:add {
    image = "elona.item_decorative_ring",
    value = 30000,
    weight = 1200,
-   pv = 50,
    material = "elona.mithril",
    level = 30,
    fltselect = 3,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
 
    is_precious = true,
@@ -64,6 +63,13 @@ data:add {
       { _id = "elona.modify_attribute", power = -1400, params = { skill_id = "elona.stat_speed", } },
       { _id = "elona.res_fear", power = 100 },
       { _id = "elona.res_paralyze", power = 100 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+         pv = 50,
+      }
    }
 }
 
@@ -74,14 +80,9 @@ data:add {
    image = "elona.item_decorative_ring",
    value = 30000,
    weight = 500,
-   pv = 5,
-   dv = 15,
    material = "elona.mithril",
    level = 30,
    fltselect = 3,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
 
    is_precious = true,
@@ -102,6 +103,14 @@ data:add {
       { _id = "elona.modify_attribute", power = 550, params = { skill_id = "elona.stat_charisma" } },
       { _id = "elona.modify_resistance", power = 200, params = { element_id = "elona.darkness" } },
       { _id = "elona.modify_resistance", power = 200, params = { element_id = "elona.chaos" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+         pv = 5,
+         dv = 15,
+      }
    }
 }
 
@@ -113,17 +122,20 @@ data:add {
    image = "elona.item_composite_ring",
    value = 450,
    weight = 50,
-   damage_bonus = 2,
    material = "elona.metal",
    level = 15,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_ring_ring",
       "elona.equip_ring"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+         damage_bonus = 2,
+      }
    }
 }
 
@@ -135,17 +147,19 @@ data:add {
    image = "elona.item_armored_ring",
    value = 450,
    weight = 50,
-   pv = 2,
    material = "elona.metal",
    level = 15,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_ring_ring",
       "elona.equip_ring"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+         pv = 2,
+      }
    }
 }
 
@@ -159,14 +173,16 @@ data:add {
    weight = 50,
    material = "elona.metal",
    level = 10,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_ring_ring",
       "elona.equip_ring"
+   },
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+      }
    }
 }
 
@@ -179,15 +195,18 @@ data:add {
    value = 5200,
    weight = 50,
    material = "elona.metal",
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    rarity = 700000,
    coefficient = 100,
    has_random_name = true,
    categories = {
       "elona.equip_ring_ring",
       "elona.equip_ring"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+      }
    },
 
    events = {
@@ -234,13 +253,8 @@ data:add {
    image = "elona.item_engagement_ring",
    value = 17000,
    weight = 50,
-   pv = 2,
-   dv = 2,
    material = "elona.metal",
    level = 15,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    rarity = 25000,
    coefficient = 100,
    has_random_name = true,
@@ -260,6 +274,14 @@ data:add {
    enchantments = {
       { _id = "elona.res_weather", power = 100 },
       { _id = "elona.modify_resistance", power = 100, params = { element_id = "elona.sound" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+         pv = 2,
+         dv = 2,
+      }
    }
 }
 
@@ -273,9 +295,6 @@ data:add {
    weight = 50,
    material = "elona.metal",
    level = 15,
-   category = 32000,
-   equip_slots = { "elona.ring" },
-   subcategory = 32001,
    rarity = 30000,
    coefficient = 100,
    has_random_name = true,
@@ -296,4 +315,10 @@ data:add {
       "elona.equip_ring_ring",
       "elona.equip_ring"
    },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.ring" },
+      }
+   }
 }

--- a/src/mod/elona/data/item/equip/shield.lua
+++ b/src/mod/elona/data/item/equip/shield.lua
@@ -1,5 +1,6 @@
 local Enum = require("api.Enum")
 local light = require("mod.elona.data.item.light")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 --
 -- Small Shield
@@ -12,13 +13,8 @@ data:add {
    image = "elona.item_knight_shield",
    value = 4800,
    weight = 2200,
-   pv = 8,
-   dv = -2,
    material = "elona.metal",
    level = 30,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -26,6 +22,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 8,
+         dv = -2,
+      }
    }
 }
 
@@ -36,12 +40,7 @@ data:add {
    image = "elona.item_small_shield",
    value = 500,
    weight = 1200,
-   pv = 4,
-   dv = 3,
    material = "elona.metal",
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -49,6 +48,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 4,
+         dv = 3,
+      }
    }
 }
 
@@ -59,13 +66,8 @@ data:add {
    image = "elona.item_round_shield",
    value = 1200,
    weight = 1500,
-   pv = 5,
-   dv = 4,
    material = "elona.metal",
    level = 10,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -73,6 +75,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 5,
+         dv = 4,
+      }
    }
 }
 
@@ -83,13 +93,8 @@ data:add {
    image = "elona.item_shield",
    value = 2500,
    weight = 1000,
-   pv = 6,
-   dv = 3,
    material = "elona.metal",
    level = 20,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -97,6 +102,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 6,
+         dv = 3,
+      }
    }
 }
 
@@ -107,13 +120,8 @@ data:add {
    image = "elona.item_large_shield",
    value = 7500,
    weight = 1400,
-   pv = 8,
-   dv = 2,
    material = "elona.metal",
    level = 40,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -121,6 +129,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 8,
+         dv = 2,
+      }
    }
 }
 
@@ -131,13 +147,8 @@ data:add {
    image = "elona.item_kite_shield",
    value = 10000,
    weight = 3500,
-   pv = 13,
-   dv = -3,
    material = "elona.metal",
    level = 50,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -145,6 +156,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 13,
+         dv = -3,
+      }
    }
 }
 
@@ -155,13 +174,8 @@ data:add {
    image = "elona.item_tower_shield",
    value = 18000,
    weight = 2400,
-   pv = 10,
-   dv = -1,
    material = "elona.metal",
    level = 60,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -169,6 +183,14 @@ data:add {
    categories = {
       "elona.equip_shield_shield",
       "elona.equip_shield"
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 10,
+         dv = -1,
+      }
    }
 }
 
@@ -179,14 +201,9 @@ data:add {
    image = "elona.item_alud",
    value = 7500,
    weight = 2850,
-   pv = 35,
-   dv = -1,
    material = "elona.wood",
    level = 15,
    fltselect = 3,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -209,6 +226,14 @@ data:add {
       { _id = "elona.modify_skill", power = -450, params = { skill_id = "elona.performer" } },
       { _id = "elona.damage_resistance", power = 400 },
       { _id = "elona.damage_immunity", power = 400 },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         pv = 35,
+         dv = -1,
+      }
    }
 }
 
@@ -219,14 +244,9 @@ data:add {
    image = "elona.item_small_shield",
    value = 17500,
    weight = 950,
-   damage_bonus = 14,
-   pv = 1,
    material = "elona.coral",
    level = 15,
    fltselect = 2,
-   category = 14000,
-   equip_slots = { "elona.hand" },
-   subcategory = 14003,
    coefficient = 100,
 
    skill = "elona.shield",
@@ -248,5 +268,13 @@ data:add {
    enchantments = {
       { _id = "elona.damage_reflection", power = 1000 },
       { _id = "elona.modify_resistance", power = 450, params = { element_id = "elona.nerve" } },
+   },
+
+   _ext = {
+      [IItemEquipment] = {
+         equip_slots = { "elona.hand" },
+         damage_bonus = 14,
+         pv = 1,
+      }
    }
 }

--- a/src/mod/elona/data/race.lua
+++ b/src/mod/elona/data/race.lua
@@ -4,6 +4,7 @@ local race =
          _id = "kobold",
          is_extra = true,
          ordering = 20010,
+         elona_id = 1,
 
          properties = {
             breed_power = 250,
@@ -41,7 +42,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -51,6 +52,7 @@ local race =
          _id = "orc",
          is_extra = true,
          ordering = 20020,
+         elona_id = 2,
 
          properties = {
             breed_power = 300,
@@ -87,7 +89,7 @@ local race =
             "elona.hand",
             "elona.hand",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -97,6 +99,7 @@ local race =
          _id = "troll",
          is_extra = true,
          ordering = 20030,
+         elona_id = 3,
 
          properties = {
             breed_power = 250,
@@ -131,7 +134,7 @@ local race =
             "elona.back",
             "elona.hand",
             "elona.hand",
-            "elona.ring",
+            "elona.arm",
             "elona.waist"
          },
       },
@@ -140,6 +143,7 @@ local race =
          _id = "lizardman",
          is_extra = true,
          ordering = 20040,
+         elona_id = 4,
 
          properties = {
             breed_power = 300,
@@ -177,7 +181,7 @@ local race =
             "elona.hand",
             "elona.hand",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -187,6 +191,7 @@ local race =
          _id = "minotaur",
          is_extra = true,
          ordering = 20050,
+         elona_id = 5,
 
          properties = {
             breed_power = 300,
@@ -230,6 +235,7 @@ local race =
          _id = "yerles",
          is_extra = false,
          ordering = 10010,
+         elona_id = 6,
 
          properties = {
             breed_power = 220,
@@ -274,7 +280,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -284,6 +290,7 @@ local race =
          _id = "norland",
          is_extra = true,
          ordering = 20060,
+         elona_id = 7,
 
          properties = {
             breed_power = 220,
@@ -324,7 +331,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -334,6 +341,7 @@ local race =
          _id = "eulderna",
          is_extra = false,
          ordering = 10020,
+         elona_id = 8,
 
          properties = {
             breed_power = 180,
@@ -377,7 +385,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -387,6 +395,7 @@ local race =
          _id = "fairy",
          is_extra = false,
          ordering = 10030,
+         elona_id = 9,
 
          properties = {
             breed_power = 180,
@@ -431,6 +440,7 @@ local race =
             ["elona.sound"] = 200,
             ["elona.chaos"] = 200,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -440,7 +450,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -449,6 +459,7 @@ local race =
          _id = "asura",
          is_extra = true,
          ordering = 20070,
+         elona_id = 10,
 
          properties = {
             breed_power = 100,
@@ -478,6 +489,7 @@ local race =
             ["elona.greater_evasion"] = 6,
             ["elona.anatomy"] = 4,
          },
+
          body_parts = {
             "elona.hand",
             "elona.hand",
@@ -490,6 +502,7 @@ local race =
          _id = "slime",
          is_extra = true,
          ordering = 20080,
+         elona_id = 11,
 
          properties = {
             breed_power = 700,
@@ -518,6 +531,7 @@ local race =
             ["elona.evasion"] = 2,
             ["elona.performer"] = 3,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -526,6 +540,7 @@ local race =
          _id = "wolf",
          is_extra = true,
          ordering = 20090,
+         elona_id = 12,
 
          properties = {
             breed_power = 800,
@@ -554,12 +569,13 @@ local race =
             ["elona.evasion"] = 2,
             ["elona.greater_evasion"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
             "elona.body",
             "elona.back",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -567,6 +583,7 @@ local race =
          _id = "dwarf",
          is_extra = false,
          ordering = 10040,
+         elona_id = 13,
 
          properties = {
             breed_power = 150,
@@ -600,6 +617,7 @@ local race =
             ["elona.jeweler"] = 3,
             ["elona.mining"] = 4,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -609,7 +627,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -618,6 +636,7 @@ local race =
          _id = "juere",
          is_extra = false,
          ordering = 10050,
+         elona_id = 14,
 
          properties = {
             breed_power = 210,
@@ -653,6 +672,7 @@ local race =
             ["elona.negotiation"] = 2,
             ["elona.throwing"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -662,7 +682,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -671,6 +691,7 @@ local race =
          _id = "zombie",
          is_extra = true,
          ordering = 20100,
+         elona_id = 15,
 
          properties = {
             breed_power = 100,
@@ -704,6 +725,7 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -711,7 +733,7 @@ local race =
             "elona.back",
             "elona.hand",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist"
          },
       },
@@ -719,6 +741,7 @@ local race =
          _id = "elea",
          is_extra = false,
          ordering = 10060,
+         elona_id = 16,
 
          properties = {
             breed_power = 120,
@@ -753,6 +776,7 @@ local race =
             ["elona.casting"] = 2,
             ["elona.memorization"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -762,7 +786,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -771,6 +795,7 @@ local race =
          _id = "rabbit",
          is_extra = true,
          ordering = 20110,
+         elona_id = 17,
 
          properties = {
             breed_power = 800,
@@ -797,18 +822,20 @@ local race =
             ["elona.martial_arts"] = 1,
             ["elona.riding"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
             "elona.body",
             "elona.back",
-            "elona.ring"
+            "elona.arm"
          },
       },
       {
          _id = "sheep",
          is_extra = true,
          ordering = 20120,
+         elona_id = 18,
 
          properties = {
             breed_power = 1000,
@@ -836,12 +863,13 @@ local race =
             ["elona.healing"] = 3,
             ["elona.anatomy"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
             "elona.body",
             "elona.back",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -849,6 +877,7 @@ local race =
          _id = "frog",
          is_extra = true,
          ordering = 20130,
+         elona_id = 19,
 
          properties = {
             breed_power = 600,
@@ -885,6 +914,7 @@ local race =
          _id = "centipede",
          is_extra = true,
          ordering = 20140,
+         elona_id = 20,
 
          properties = {
             breed_power = 400,
@@ -911,6 +941,7 @@ local race =
             ["elona.martial_arts"] = 1,
             ["elona.eye_of_mind"] = 3,
          },
+
          body_parts = {
             "elona.back",
             "elona.ring",
@@ -921,6 +952,7 @@ local race =
          _id = "snail",
          is_extra = false,
          ordering = 10070,
+         elona_id = 21,
 
          properties = {
             breed_power = 500,
@@ -947,6 +979,7 @@ local race =
             ["elona.martial_arts"] = 1,
             ["elona.throwing"] = 5,
          },
+
          body_parts = {
             "elona.back"
          },
@@ -955,6 +988,7 @@ local race =
          _id = "mandrake",
          is_extra = true,
          ordering = 20150,
+         elona_id = 22,
 
          properties = {
             breed_power = 80,
@@ -983,6 +1017,7 @@ local race =
             ["elona.literacy"] = 2,
             ["elona.magic_capacity"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.back"
@@ -992,6 +1027,7 @@ local race =
          _id = "beetle",
          is_extra = true,
          ordering = 20160,
+         elona_id = 23,
 
          properties = {
             breed_power = 750,
@@ -1020,6 +1056,7 @@ local race =
             ["elona.detection"] = 3,
             ["elona.stealth"] = 3,
          },
+
          body_parts = {
             "elona.neck"
          },
@@ -1028,6 +1065,7 @@ local race =
          _id = "mushroom",
          is_extra = true,
          ordering = 20170,
+         elona_id = 24,
 
          properties = {
             breed_power = 440,
@@ -1057,6 +1095,7 @@ local race =
             ["elona.tailoring"] = 3,
             ["elona.alchemy"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck"
@@ -1066,6 +1105,7 @@ local race =
          _id = "bat",
          is_extra = true,
          ordering = 20180,
+         elona_id = 25,
 
          properties = {
             breed_power = 350,
@@ -1094,6 +1134,7 @@ local race =
             ["elona.martial_arts"] = 2,
             ["elona.greater_evasion"] = 3,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -1102,6 +1143,7 @@ local race =
          _id = "ent",
          is_extra = true,
          ordering = 20190,
+         elona_id = 26,
 
          properties = {
             breed_power = 35,
@@ -1129,11 +1171,12 @@ local race =
             ["elona.healing"] = 2,
             ["elona.carpentry"] = 4,
          },
+
          body_parts = {
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -1141,6 +1184,7 @@ local race =
          _id = "lich",
          is_extra = false,
          ordering = 10080,
+         elona_id = 27,
 
          properties = {
             breed_power = 25,
@@ -1183,6 +1227,7 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1192,7 +1237,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -1201,6 +1246,7 @@ local race =
          _id = "hound",
          is_extra = true,
          ordering = 20200,
+         elona_id = 28,
 
          properties = {
             breed_power = 540,
@@ -1230,6 +1276,7 @@ local race =
             ["elona.detection"] = 4,
             ["elona.performer"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1242,6 +1289,7 @@ local race =
          _id = "ghost",
          is_extra = true,
          ordering = 20210,
+         elona_id = 29,
 
          properties = {
             breed_power = 30,
@@ -1277,6 +1325,7 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1292,6 +1341,7 @@ local race =
          _id = "spirit",
          is_extra = true,
          ordering = 20220,
+         elona_id = 30,
 
          properties = {
             breed_power = 25,
@@ -1319,6 +1369,7 @@ local race =
             ["elona.casting"] = 3,
             ["elona.control_magic"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1334,6 +1385,7 @@ local race =
          _id = "eye",
          is_extra = true,
          ordering = 20230,
+         elona_id = 31,
 
          properties = {
             breed_power = 50,
@@ -1362,6 +1414,7 @@ local race =
             ["elona.detection"] = 3,
             ["elona.anatomy"] = 3,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -1370,6 +1423,7 @@ local race =
          _id = "wyvern",
          is_extra = true,
          ordering = 20240,
+         elona_id = 32,
 
          properties = {
             breed_power = 100,
@@ -1398,6 +1452,7 @@ local race =
             ["elona.literacy"] = 3,
             ["elona.traveling"] = 3,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1409,6 +1464,7 @@ local race =
          _id = "wasp",
          is_extra = true,
          ordering = 20250,
+         elona_id = 33,
 
          properties = {
             breed_power = 580,
@@ -1437,6 +1493,7 @@ local race =
             ["elona.martial_arts"] = 2,
             ["elona.greater_evasion"] = 2,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -1445,6 +1502,7 @@ local race =
          _id = "giant",
          is_extra = true,
          ordering = 20260,
+         elona_id = 34,
 
          properties = {
             breed_power = 60,
@@ -1473,12 +1531,13 @@ local race =
             ["elona.magic_device"] = 2,
             ["elona.carpentry"] = 3,
          },
+
          body_parts = {
             "elona.body",
             "elona.back",
             "elona.hand",
             "elona.hand",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -1486,6 +1545,7 @@ local race =
          _id = "imp",
          is_extra = true,
          ordering = 20270,
+         elona_id = 35,
 
          properties = {
             breed_power = 240,
@@ -1515,6 +1575,7 @@ local race =
             ["elona.memorization"] = 3,
             ["elona.control_magic"] = 3,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1529,6 +1590,7 @@ local race =
          _id = "hand",
          is_extra = true,
          ordering = 20280,
+         elona_id = 36,
 
          properties = {
             breed_power = 160,
@@ -1555,18 +1617,20 @@ local race =
             ["elona.martial_arts"] = 2,
             ["elona.eye_of_mind"] = 4,
          },
+
          body_parts = {
             "elona.hand",
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring"
+            "elona.arm"
          },
       },
       {
          _id = "snake",
          is_extra = true,
          ordering = 20290,
+         elona_id = 37,
 
          properties = {
             breed_power = 430,
@@ -1598,14 +1662,12 @@ local race =
          body_parts = {
             "elona.body"
          },
-
-
-
       },
       {
          _id = "drake",
          is_extra = true,
          ordering = 20300,
+         elona_id = 38,
 
          properties = {
             breed_power = 120,
@@ -1635,6 +1697,7 @@ local race =
             ["elona.traveling"] = 3,
             ["elona.fishing"] = 2,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1646,6 +1709,7 @@ local race =
          _id = "goblin",
          is_extra = false,
          ordering = 10090,
+         elona_id = 39,
 
          properties = {
             breed_power = 290,
@@ -1680,6 +1744,7 @@ local race =
             ["elona.mining"] = 2,
             ["elona.eye_of_mind"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1689,7 +1754,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -1698,6 +1763,7 @@ local race =
          _id = "bear",
          is_extra = true,
          ordering = 20310,
+         elona_id = 40,
 
          properties = {
             breed_power = 350,
@@ -1727,12 +1793,13 @@ local race =
             ["elona.performer"] = 2,
             ["elona.eye_of_mind"] = 3,
          },
+
          body_parts = {
             "elona.hand",
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -1741,6 +1808,7 @@ local race =
          _id = "armor",
          is_extra = true,
          ordering = 20320,
+         elona_id = 41,
 
          properties = {
             breed_power = 40,
@@ -1770,6 +1838,7 @@ local race =
             ["elona.lock_picking"] = 3,
             ["elona.magic_device"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -1777,7 +1846,7 @@ local race =
             "elona.back",
             "elona.hand",
             "elona.hand",
-            "elona.ring",
+            "elona.arm",
             "elona.waist"
          },
       },
@@ -1785,6 +1854,7 @@ local race =
          _id = "medusa",
          is_extra = true,
          ordering = 20330,
+         elona_id = 42,
 
          properties = {
             breed_power = 180,
@@ -1813,13 +1883,14 @@ local race =
             ["elona.magic_capacity"] = 3,
             ["elona.control_magic"] = 3,
          },
+
          body_parts = {
             "elona.body",
             "elona.hand",
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -1827,6 +1898,7 @@ local race =
          _id = "cupid",
          is_extra = true,
          ordering = 20340,
+         elona_id = 43,
 
          properties = {
             breed_power = 350,
@@ -1855,6 +1927,7 @@ local race =
             ["elona.literacy"] = 4,
             ["elona.control_magic"] = 3,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1862,13 +1935,14 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring"
+            "elona.arm"
          },
       },
       {
          _id = "phantom",
          is_extra = true,
          ordering = 20350,
+         elona_id = 44,
          properties = {
             breed_power = 35,
             image = "elona.chara_phantom",
@@ -1903,6 +1977,7 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1910,13 +1985,14 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring"
+            "elona.arm"
          },
       },
       {
          _id = "harpy",
          is_extra = true,
          ordering = 20360,
+         elona_id = 45,
          properties = {
             breed_power = 420,
             image = "elona.chara_harpy",
@@ -1944,13 +2020,14 @@ local race =
             ["elona.magic_capacity"] = 3,
             ["elona.magic_device"] = 2,
          },
+
          body_parts = {
             "elona.neck",
             "elona.hand",
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.leg",
             "elona.leg"
          },
@@ -1959,6 +2036,7 @@ local race =
          _id = "dragon",
          is_extra = true,
          ordering = 20370,
+         elona_id = 46,
 
          properties = {
             breed_power = 20,
@@ -1988,6 +2066,7 @@ local race =
             ["elona.traveling"] = 3,
             ["elona.jeweler"] = 3,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -1999,6 +2078,7 @@ local race =
          _id = "dinosaur",
          is_extra = true,
          ordering = 20380,
+         elona_id = 47,
 
          properties = {
             breed_power = 100,
@@ -2028,6 +2108,7 @@ local race =
             ["elona.traveling"] = 3,
             ["elona.greater_evasion"] = 2,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -2039,6 +2120,7 @@ local race =
          _id = "cerberus",
          is_extra = true,
          ordering = 20390,
+         elona_id = 48,
 
          properties = {
             breed_power = 80,
@@ -2067,12 +2149,13 @@ local race =
             ["elona.detection"] = 3,
             ["elona.tailoring"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
             "elona.body",
             "elona.back",
-            "elona.ring",
+            "elona.arm",
             "elona.leg",
             "elona.leg"
          },
@@ -2081,6 +2164,7 @@ local race =
          _id = "spider",
          is_extra = true,
          ordering = 20400,
+         elona_id = 49,
 
          properties = {
             breed_power = 560,
@@ -2113,6 +2197,7 @@ local race =
             ["elona.stealth"] = 3,
             ["elona.anatomy"] = 5,
          },
+
          body_parts = {
             "elona.ring",
             "elona.ring"
@@ -2122,6 +2207,7 @@ local race =
          _id = "golem",
          is_extra = false,
          ordering = 10100,
+         elona_id = 50,
 
          properties = {
             breed_power = 40,
@@ -2156,6 +2242,7 @@ local race =
             ["elona.weight_lifting"] = 5,
             ["elona.mining"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2165,10 +2252,11 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
+
 
          -- >>>>>>>> shade2/chara_func.hsp:934 		if cnRace(tc)="golem":f=false ...
          effect_immunities = {
@@ -2180,6 +2268,7 @@ local race =
          _id = "rock",
          is_extra = true,
          ordering = 20410,
+         elona_id = 51,
 
          properties = {
             breed_power = 200,
@@ -2209,6 +2298,7 @@ local race =
             ["elona.weight_lifting"] = 3,
             ["elona.mining"] = 3,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -2217,6 +2307,7 @@ local race =
          _id = "crab",
          is_extra = true,
          ordering = 20420,
+         elona_id = 52,
 
          properties = {
             breed_power = 420,
@@ -2246,6 +2337,7 @@ local race =
             ["elona.disarm_trap"] = 2,
             ["elona.shield"] = 3,
          },
+
          body_parts = {
             "elona.back",
             "elona.hand",
@@ -2259,6 +2351,7 @@ local race =
          _id = "skeleton",
          is_extra = true,
          ordering = 20430,
+         elona_id = 53,
 
          properties = {
             breed_power = 30,
@@ -2294,6 +2387,7 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2303,7 +2397,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2312,6 +2406,7 @@ local race =
          _id = "piece",
          is_extra = true,
          ordering = 20440,
+         elona_id = 54,
 
          properties = {
             breed_power = 25,
@@ -2341,6 +2436,7 @@ local race =
             ["elona.magic_capacity"] = 2,
             ["elona.literacy"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2350,7 +2446,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist"
          },
       },
@@ -2358,6 +2454,7 @@ local race =
          _id = "cat",
          is_extra = true,
          ordering = 20450,
+         elona_id = 55,
 
          properties = {
             breed_power = 950,
@@ -2388,6 +2485,7 @@ local race =
             ["elona.greater_evasion"] = 3,
             ["elona.evasion"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2402,6 +2500,7 @@ local race =
          _id = "dog",
          is_extra = true,
          ordering = 20460,
+         elona_id = 56,
 
          properties = {
             breed_power = 920,
@@ -2431,6 +2530,7 @@ local race =
             ["elona.performer"] = 2,
             ["elona.detection"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2445,6 +2545,7 @@ local race =
          _id = "roran",
          is_extra = true,
          ordering = 20470,
+         elona_id = 57,
 
          properties = {
             breed_power = 220,
@@ -2474,6 +2575,7 @@ local race =
             ["elona.literacy"] = 4,
             ["elona.investing"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2483,7 +2585,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2492,6 +2594,7 @@ local race =
          _id = "rat",
          is_extra = true,
          ordering = 20480,
+         elona_id = 58,
 
          properties = {
             breed_power = 1100,
@@ -2520,9 +2623,10 @@ local race =
             ["elona.stealth"] = 3,
             ["elona.anatomy"] = 2,
          },
+
          body_parts = {
             "elona.back",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2531,6 +2635,7 @@ local race =
          _id = "shell",
          is_extra = true,
          ordering = 20490,
+         elona_id = 59,
 
          properties = {
             breed_power = 450,
@@ -2560,6 +2665,7 @@ local race =
             ["elona.meditation"] = 3,
             ["elona.sense_quality"] = 3,
          },
+
          body_parts = {
             "elona.leg"
          },
@@ -2568,6 +2674,7 @@ local race =
          _id = "catgod",
          is_extra = true,
          ordering = 20500,
+         elona_id = 60,
 
          properties = {
             breed_power = 5,
@@ -2598,13 +2705,14 @@ local race =
             ["elona.greater_evasion"] = 3,
             ["elona.eye_of_mind"] = 2,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
             "elona.body",
             "elona.hand",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -2612,6 +2720,7 @@ local race =
          _id = "machinegod",
          is_extra = true,
          ordering = 20510,
+         elona_id = 61,
 
          properties = {
             breed_power = 5,
@@ -2640,13 +2749,14 @@ local race =
             ["elona.martial_arts"] = 5,
             ["elona.firearm"] = 30,
          },
+
          body_parts = {
             "elona.head",
             "elona.body",
             "elona.back",
             "elona.hand",
             "elona.hand",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2655,6 +2765,7 @@ local race =
          _id = "undeadgod",
          is_extra = true,
          ordering = 20520,
+         elona_id = 62,
 
          properties = {
             breed_power = 5,
@@ -2682,6 +2793,7 @@ local race =
             ["elona.control_magic"] = 3,
             ["elona.magic_capacity"] = 5,
          },
+
          body_parts = {
             "elona.neck",
             "elona.body",
@@ -2696,6 +2808,7 @@ local race =
          _id = "machine",
          is_extra = true,
          ordering = 20530,
+         elona_id = 63,
 
          properties = {
             breed_power = 15,
@@ -2726,6 +2839,7 @@ local race =
             ["elona.lock_picking"] = 3,
             ["elona.disarm_trap"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2735,7 +2849,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2744,6 +2858,7 @@ local race =
          _id = "wisp",
          is_extra = true,
          ordering = 20540,
+         elona_id = 64,
 
          properties = {
             breed_power = 25,
@@ -2772,6 +2887,7 @@ local race =
             ["elona.control_magic"] = 3,
             ["elona.magic_capacity"] = 5,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -2780,6 +2896,7 @@ local race =
          _id = "chicken",
          is_extra = true,
          ordering = 20550,
+         elona_id = 65,
 
          properties = {
             breed_power = 1000,
@@ -2808,6 +2925,7 @@ local race =
             ["elona.anatomy"] = 3,
             ["elona.meditation"] = 3,
          },
+
          body_parts = {
             "elona.head"
          },
@@ -2816,6 +2934,7 @@ local race =
          _id = "stalker",
          is_extra = true,
          ordering = 20560,
+         elona_id = 66,
 
          properties = {
             breed_power = 25,
@@ -2851,19 +2970,21 @@ local race =
             ["elona.nether"] = 500,
             ["elona.fire"] = 80,
          },
+
          body_parts = {
             "elona.neck",
             "elona.hand",
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring"
+            "elona.arm"
          },
       },
       {
          _id = "catsister",
          is_extra = true,
          ordering = 20570,
+         elona_id = 67,
 
          properties = {
             breed_power = 5,
@@ -2892,6 +3013,7 @@ local race =
             ["elona.two_hand"] = 6,
             ["elona.tactics"] = 4,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2901,7 +3023,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2910,6 +3032,7 @@ local race =
          _id = "mutant",
          is_extra = false,
          ordering = 10110,
+         elona_id = 68,
 
          properties = {
             breed_power = 50,
@@ -2941,6 +3064,7 @@ local race =
             ["elona.magic_capacity"] = 3,
             ["elona.healing"] = 4,
          },
+
          body_parts = {
             "elona.body",
             "elona.hand"
@@ -2950,6 +3074,7 @@ local race =
          _id = "yeek",
          is_extra = true,
          ordering = 20580,
+         elona_id = 69,
 
          properties = {
             breed_power = 500,
@@ -2977,6 +3102,7 @@ local race =
             ["elona.meditation"] = 3,
             ["elona.negotiation"] = 4,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -2986,7 +3112,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -2995,6 +3121,7 @@ local race =
          _id = "yith",
          is_extra = true,
          ordering = 20590,
+         elona_id = 70,
 
          properties = {
             breed_power = 25,
@@ -3025,6 +3152,7 @@ local race =
             ["elona.meditation"] = 3,
             ["elona.faith"] = 4,
          },
+
          body_parts = {
             "elona.hand",
             "elona.hand",
@@ -3040,6 +3168,7 @@ local race =
          _id = "servant",
          is_extra = true,
          ordering = 20600,
+         elona_id = 71,
 
          properties = {
             breed_power = 5,
@@ -3072,6 +3201,7 @@ local race =
             ["elona.firearm"] = 4,
             ["elona.two_hand"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -3081,7 +3211,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.waist",
             "elona.leg"
          },
@@ -3090,6 +3220,7 @@ local race =
          _id = "horse",
          is_extra = true,
          ordering = 20610,
+         elona_id = 72,
 
          properties = {
             breed_power = 1000,
@@ -3117,6 +3248,7 @@ local race =
             ["elona.martial_arts"] = 1,
             ["elona.healing"] = 4,
          },
+
          body_parts = {
             "elona.body",
             "elona.leg",
@@ -3127,6 +3259,7 @@ local race =
          _id = "god",
          is_extra = true,
          ordering = 20620,
+         elona_id = 73,
 
          properties = {
             breed_power = 1,
@@ -3162,6 +3295,7 @@ local race =
             ["elona.two_hand"] = 5,
             ["elona.tactics"] = 7,
          },
+
          body_parts = {
             "elona.hand",
             "elona.hand"
@@ -3171,6 +3305,7 @@ local race =
          _id = "quickling",
          is_extra = true,
          ordering = 20630,
+         elona_id = 74,
 
          properties = {
             breed_power = 1,
@@ -3203,6 +3338,7 @@ local race =
          resistances = {
             ["elona.magic"] = 500,
          },
+
          body_parts = {
             "elona.head",
             "elona.body",
@@ -3211,7 +3347,7 @@ local race =
             "elona.hand",
             "elona.ring",
             "elona.ring",
-            "elona.ring",
+            "elona.arm",
             "elona.leg"
          },
       },
@@ -3219,6 +3355,7 @@ local race =
          _id = "metal",
          is_extra = true,
          ordering = 20640,
+         elona_id = 75,
 
          properties = {
             breed_power = 1,
@@ -3252,6 +3389,7 @@ local race =
          resistances = {
             ["elona.magic"] = 500,
          },
+
          body_parts = {
             "elona.head",
             "elona.body",
@@ -3262,6 +3400,7 @@ local race =
          _id = "bike",
          is_extra = true,
          ordering = 20650,
+         elona_id = 76,
 
          properties = {
             breed_power = 15,
@@ -3293,6 +3432,7 @@ local race =
             ["elona.lock_picking"] = 3,
             ["elona.disarm_trap"] = 3,
          },
+
          body_parts = {
             "elona.head",
             "elona.body",
@@ -3328,6 +3468,7 @@ local race =
             ["elona.stat_speed"] = 500,
             ["elona.mining"] = 100,
          },
+
          body_parts = {
             "elona.head",
             "elona.neck",
@@ -3341,7 +3482,6 @@ local race =
             "elona.waist",
             "elona.leg"
          },
-
       },
    }
 

--- a/src/mod/elona/test/api/aspect/IItemEquipment.lua
+++ b/src/mod/elona/test/api/aspect/IItemEquipment.lua
@@ -1,0 +1,14 @@
+local Item = require("api.Item")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
+local Assert = require("api.test.Assert")
+
+function test_IItemEquipment_init()
+   local item = Item.create("elona.dragon_slayer", nil, nil, {ownerless=true})
+   local equip = item:get_aspect(IItemEquipment)
+
+   Assert.is_truthy(equip)
+   Assert.eq(-42, equip.dv)
+   Assert.eq(30, equip.pv)
+   Assert.eq(-25, equip.hit_bonus)
+   Assert.eq(20, equip.damage_bonus)
+end

--- a/src/mod/weird_thing/data/item.lua
+++ b/src/mod/weird_thing/data/item.lua
@@ -7,6 +7,7 @@ local IItemBlacksmithHammer = require("mod.smithing.api.aspect.IItemBlacksmithHa
 local Gui = require("api.Gui")
 local Item = require("api.Item")
 local Rand = require("api.Rand")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 data:add {
    _type = "elona.plant",
@@ -58,6 +59,14 @@ data:add {
       [IItemMuseumValued] = {
          museum_value = 100
       },
-      [IItemBlacksmithHammer] = {}
+      [IItemBlacksmithHammer] = {},
+      [IItemEquipment] = {
+         dv = 10,
+         pv = 10,
+         hit_bonus = 10,
+         damage_bonus = 10,
+         equip_slots = { "elona.hand", "elona.arm", "elona.back" },
+         pcc_part = 1
+      }
    }
 }

--- a/src/scratch/2021-04-17_21-11-48.lua
+++ b/src/scratch/2021-04-17_21-11-48.lua
@@ -1,0 +1,45 @@
+local Csv = require("mod.extlibs.api.Csv")
+local Compat = require("mod.elona_sys.api.Compat")
+local CodeGenerator = require("api.CodeGenerator")
+
+local FIGURE_TO_BODY_PART = {
+   ["頭"] = "elona.head",
+   ["首"] = "elona.neck",
+   ["体"] = "elona.body",
+   ["背"] = "elona.back",
+   ["手"] = "elona.hand",
+   ["指"] = "elona.ring",
+   ["腕"] = "elona.arm",
+   ["腰"] = "elona.waist",
+   ["足"] = "elona.leg",
+   ["足"] = "elona.leg",
+   ["足"] = "elona.leg",
+}
+
+local map = function(row)
+   local _id = Compat.convert_122_id("base.race", tonumber(string.strip_whitespace(row.id2)))
+
+   local figure = row.figure
+   figure = string.split(figure, "|")
+   figure = fun.iter(figure)
+      :flatmap(function(f) return fun.wrap(utf8.chars(f)):to_list() end)
+      :filter(function(f) return f ~= "" end)
+      :to_list()
+
+   local body_parts = fun.iter(figure):map(function(f) return assert(FIGURE_TO_BODY_PART[f], f) end):to_list()
+
+   return {
+      _id = row.id,
+      elona_id = assert(tonumber(string.strip_whitespace(row.id2))),
+      body_parts = body_parts
+   }
+end
+
+for _, row in Csv.parse_file("../../study/elona122/shade2/db/race.csv", {header=true, shift_jis=true})
+   :map(map)
+   :filter(fun.op.truth)
+do
+   local gen = CodeGenerator:new()
+   gen:write_table(row)
+   print(gen)
+end

--- a/src/test/api/IAspectHolder.lua
+++ b/src/test/api/IAspectHolder.lua
@@ -123,3 +123,18 @@ function test_IAspectHolder_calc_aspect()
 
    Assert.eq(42, item:calc_aspect(AspectHolder_ITestAspect, "foo"))
 end
+
+function test_IAspectHolder_get_aspect_proto()
+   local item = Item.create("@test@.aspected", nil, nil, {ownerless = true})
+
+   local proto = item:get_aspect_proto(AspectHolder_ITestAspect)
+   Assert.same({}, proto)
+end
+
+function test_IAspectHolder_get_aspect_proto__params()
+   local item = Item.create("@test@.aspected_with_params", nil, nil, {ownerless = true})
+
+   local proto = item:get_aspect_proto(AspectHolder_ITestAspect)
+   Assert.is_truthy(proto)
+   Assert.eq(42, proto.my_foo)
+end

--- a/src/test/api/chara/ICharaEquip.lua
+++ b/src/test/api/chara/ICharaEquip.lua
@@ -162,3 +162,39 @@ function test_ICharaEquip_iter_merged_enchantments__multiple()
    Assert.is_truthy(chara:unequip_item(item2))
    Assert.eq(0, ICharaEquip.iter_merged_enchantments(chara):length())
 end
+
+function test_ICharaEquip_on_refresh__weapon_bonuses()
+   local item = TestUtil.stripped_item("elona.dragon_slayer")
+   local chara = TestUtil.stripped_chara("elona.wizard_of_elea")
+
+   Assert.eq(0, chara:calc("dv"))
+   Assert.eq(0, chara:calc("pv"))
+   Assert.eq(0, chara:calc("hit_bonus"))
+   Assert.eq(0, chara:calc("damage_bonus"))
+
+   Assert.is_truthy(chara:take_item(item))
+   Assert.is_truthy(chara:equip_item(item))
+   chara:refresh()
+   Assert.eq(-42, chara:calc("dv"))
+   Assert.eq(30, chara:calc("pv"))
+   Assert.eq(0, chara:calc("hit_bonus"))
+   Assert.eq(0, chara:calc("damage_bonus"))
+end
+
+function test_ICharaEquip_on_refresh__equipment_bonuses()
+   local item = TestUtil.stripped_item("elona.gloves")
+   local chara = TestUtil.stripped_chara("elona.wizard_of_elea")
+
+   Assert.eq(0, chara:calc("dv"))
+   Assert.eq(0, chara:calc("pv"))
+   Assert.eq(0, chara:calc("hit_bonus"))
+   Assert.eq(0, chara:calc("damage_bonus"))
+
+   Assert.is_truthy(chara:take_item(item))
+   Assert.is_truthy(chara:equip_item(item))
+   chara:refresh()
+   Assert.eq(5, chara:calc("dv"))
+   Assert.eq(4, chara:calc("pv"))
+   Assert.eq(5, chara:calc("hit_bonus"))
+   Assert.eq(1, chara:calc("damage_bonus"))
+end

--- a/src/test/event/instantiate_item.lua
+++ b/src/test/event/instantiate_item.lua
@@ -4,6 +4,7 @@ local TestUtil = require("api.test.TestUtil")
 local Item = require("api.Item")
 local Assert = require("api.test.Assert")
 local data = require("internal.data")
+local IItemEquipment = require("mod.elona.api.aspect.IItemEquipment")
 
 data:add {
    _type = "base.item",
@@ -11,10 +12,7 @@ data:add {
 
    dice_x = 2,
    dice_y = 7,
-   hit_bonus = 4,
-   damage_bonus = 8,
    material = "elona.metal",
-   equip_slots = { "elona.ranged" },
    coefficient = 100,
 
    skill = "elona.bow",
@@ -24,7 +22,15 @@ data:add {
       "elona.equip_ranged"
    },
 
-   on_use = nil
+   on_use = nil,
+
+   _ext = {
+      [IItemEquipment] = {
+         hit_bonus = 4,
+         damage_bonus = 8,
+         equip_slots = { "elona.ranged" },
+      }
+   }
 }
 
 data:add {
@@ -33,10 +39,7 @@ data:add {
 
    dice_x = 2,
    dice_y = 7,
-   hit_bonus = 4,
-   damage_bonus = 8,
    material = "elona.metal",
-   equip_slots = { "elona.ranged" },
    coefficient = 100,
 
    skill = "elona.bow",
@@ -46,7 +49,15 @@ data:add {
       "elona.equip_ranged"
    },
 
-   on_use = function() end
+   on_use = function() end,
+
+   _ext = {
+      [IItemEquipment] = {
+         hit_bonus = 4,
+         damage_bonus = 8,
+         equip_slots = { "elona.ranged" },
+      }
+   }
 }
 
 function test_item_event_emitter_callbacks_restored()


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

#15.

### Description

Makes equipment use an aspect. It doesn't handle melee or ranged weapons yet, just DV/PV/hit bonus/damage bonus.
