### PR TITLE
Add omake overhaul EN translations to story cutscenes

### DIFF
--- a/src/mod/elona/data/dialog/unique/orphe.lua
+++ b/src/mod/elona/data/dialog/unique/orphe.lua
@@ -7,7 +7,7 @@ data:add {
 
    nodes = {
       __start = function()
-         return "elona_sys.ignores_you:__start"
+         return "elona.ignores_you:__start"
       end,
       dialog = {
          text = {

--- a/src/mod/elona/data/scene/en.lua
+++ b/src/mod/elona/data/scene/en.lua
@@ -1,7 +1,7 @@
 local story_0 = {
-    { "pic", "base.bg3" },
-    { "mc", "elona.intro" },
-    {
+   { "pic", "base.bg3" },
+   { "mc", "elona.intro" },
+   {
       "txt",
       [[
 Ages ago, in the times when the scars
@@ -13,8 +13,8 @@ still plagued by destruction and war
 and though prophesized as the beginnings of peace,
 Sierre Terre brought chaos as well as hope.
 ]]
-    },
-    {
+   },
+   {
       "txt",
       [[
 It rained for over a month.
@@ -32,8 +32,8 @@ As the forest devoured the land,
 it drove countless refugees into the
 western reaches of the continent.
 ]]
-    },
-    {
+   },
+   {
       "txt",
       [[
 But then, not so long ago,
@@ -53,9 +53,9 @@ fled deep into the Vindale.
 Now, the conflict grows worse with each passing day
 and a final confrontation becomes more and more inevitable.
 ]]
-    },
-    { "pic", "base.bg4" },
-    {
+   },
+   { "pic", "base.bg4" },
+   {
       "txt",
       [[
 The night has almost passed.
@@ -78,8 +78,8 @@ An old sailor mutters a faint curse under his breath.
 
 "The ether wind descends upon us..."
 ]]
-    },
-    {
+   },
+   {
       "txt",
       [[
 The ship roars in misery as the very planks
@@ -95,10 +95,10 @@ is swallowed into the depths of the sea, is the mysterious
 dancing light of the ether winds drifting away
 from you as sink into the depths...
 ]]
-    },
-    { "fade" }
-  }
+   },
+   { "fade" }
+}
 
 return {
-  story_0 = story_0
+   story_0 = story_0
 }

--- a/src/mod/elona_sys/scene/api/SceneLayer.lua
+++ b/src/mod/elona_sys/scene/api/SceneLayer.lua
@@ -94,6 +94,7 @@ function SceneLayer:proceed()
         finished = true
       elseif id == "pic" then
         self.bg = t[2]
+        assert(data["base.asset"][self.bg], "Missing scene bg '" .. self.bg .. "'")
       elseif id == "chat" then
         finished = true
       elseif id == "actor" then
@@ -142,8 +143,9 @@ function SceneLayer:draw()
   Draw.set_color(0, 0, 0)
   Draw.filled_rect(0, 0, self.width, self.height)
   if self.bg then
-    Draw.set_color(255, 255, 255)
-    self.t[self.bg]:draw(0, y1, self.width, y2-y1)
+     local bg = assert(self.t[self.bg])
+     Draw.set_color(255, 255, 255)
+     bg:draw(0, y1, self.width, y2-y1)
   end
 
   Draw.set_color(255, 255, 255)

--- a/src/mod/oo_en/README.md
+++ b/src/mod/oo_en/README.md
@@ -1,0 +1,5 @@
+# oo_en
+
+Ports the English translations for Elona's original story cutscenes from oo_en.
+
+All credit for the translations goes to Doorknob.

--- a/src/mod/oo_en/data/init.lua
+++ b/src/mod/oo_en/data/init.lua
@@ -1,0 +1,1 @@
+require("mod.oo_en.data.scene.init")

--- a/src/mod/oo_en/data/scene/en.lua
+++ b/src/mod/oo_en/data/scene/en.lua
@@ -1,0 +1,1794 @@
+-- The English translations here were originally authored by Doorknob.
+
+local story_0 = {
+   { "pic", "base.bg3" },
+   { "mc", "elona.intro" },
+   {
+      "txt",
+      [[
+In times long past, the land of Ylva has seen ten great civilizations,
+the ruins of which still dot the land. The scars left by the previous
+civilization, Rehm-Ido, have yet to heal. This is a story of Sierra Terre,
+the 11th era, said to be the most destructive and yet most revitalizing of them all.
+]]
+   },
+   {
+      "txt",
+      [[
+A month of rain plagued the frontier lands of Karune, and once it cleared,
+the Vindale Forest began to change. The Forest rapidly spread its roots,
+and began emanating a strange fog which created an environment
+uninhabitable by people.
+
+The Vindale Forest quickly overtook the land of the people of Karune,
+and refugees poured into North Tyris.
+
+A prince from Zanan, one of the Western countries, preaches that
+this phenomenon is the very same calamity that befell Rehm-Ido
+and advocates for the destruction of both the Heretical Forest
+and the Elean people.
+
+The Elea of Vindale began to retreat from human lands to avoid persecution,
+but the world's animosity towards them is still afire. The flames of war threaten
+to ignite at any moment.
+]]
+   },
+   { "pic", "base.bg4" },
+   {
+      "txt",
+      [[
+The dawn will soon arrive. You had slipped in with the cargo of the merchant
+ship Queen Sedona which was headed for North Tyris.  Suddenly you are
+awakened by a thundering roar.
+
+The air is alight with the sound of splitting wood as violent waves crash
+ into the ship and terrible winds assault the sails. An old sailor curses his
+ God and mutters:
+
+ "It's the Ether Wind"
+
+...The wood of the ship gives a final moan as the violent waves crush the hull.
+Without even time for her passengers to say a final prayer, the Queen Sedona
+ is swallowed by the sea.]]
+   },
+   { "fade" }
+}
+
+local story_1 = {
+   {
+      "actor", 1,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   { "mc", "elona.town1" },
+   { "pic", "base.bg1" },
+   {
+      "txt",
+      [[
+A soldier bearing the crest of Zanan hails you as you enter the town of Vernis.
+
+After a round of careful questioning, the Zanan soldier that had regarded you
+with suspicion informs you that the Crown Prince of Zanan is in the town on
+campaign.
+
+You notice that a crowd is gathered in the village square, listening intently to
+the albino prince that leans weakly against his attendant.
+
+]]
+   },
+   { "mc", "elona.unrest2" },
+   {
+      "chat", 1,
+      "...And so I am overcome with grief. Zanan has lost the war with the new Kingdoms, and without its leader, shall become host to the conflict between the two great nations for many years to come. Even if the late Prince Clyne were still alive and was to make a bid for peace, the war between these nations would not be silenced."
+   },
+   {
+      "chat", 1,
+      "War... Can not these nations who wish to stain themselves with blood and flame recognize that an unimaginable crisis has befallen Sierra Terre? These evil winds spoil our forests, take the lives of our countrymen, and rob us of our lands. The Elea and their Heretical Forest plan to revive the Meshera, the nightmares that destroyed the civilization of Rehm-Ido."
+   },
+   {
+      "chat", 1,
+      "Now is the time for unity - A great trial has been thrust upon Ylva, and if we put aside our petty squabbles and learn to understand one another, we can destroy the Heretics and their Forest. Together we can overcome this catastrophe."
+   },
+   {
+      "chat", 1,
+      "Zanan is no longer the superpower that it once was. But hear me, my friends: we are not powerless. Palmia, which has heretofore withstood the power of the two great nations and has the faith and determination of its people, is the hope of Sierra Terre."
+   },
+   {
+      "txt",
+      [[
+A great cheer rose from the square.
+
+The speaker's voice was drowned out by the sound, no longer reaching your
+ears where you stood at the back of the crowd.
+
+You leave the square slowly, remembering the albino prince with a strange sense
+of both unease and interest.
+]]
+   },
+   { "fade" }
+}
+
+local story_100 = {
+   { "pic", "base.bg12" },
+   { "mc", "elona.epilogue" },
+   {
+      "txt",
+      [[
+-Epilogue-
+
+<At the end of every adventure lies a new journey.>
+]]
+   },
+   {
+      "txt",
+      [[
+The Vindale Forest was lost.
+
+Though the people who heard the
+news praised the Prince of Zanan,
+the world gradually began to change.
+]]
+   },
+   {
+      "txt",
+      [[
+Unknown illnesses began to spread,
+crops withered, and dry winds raged.
+
+By the time people began to notice these
+strange occurrences, Barius of Zanan had a
+female Elea, a survivor of the war, standing
+witness before the Imperial Court.
+]]
+   },
+   {
+      "txt",
+      [[
+The woman told the world the truth.
+
+The Vindale Forest, which people had
+referred to as the Heretical Forest, had
+been suppressing the power of the Meshera.
+
+And with the destruction of the
+Forest, Ylva would soon change to
+become uninhabitable by all peoples.
+]]
+   },
+   {
+      "txt",
+      [[
+The people of Ylva were taken aback by this testimony.
+
+Some were heartbroken, others
+filled with regret, and as always,
+others cared not at all.
+
+Dark times had come to Sierra Terre.
+]]
+   },
+   {
+      "txt",
+      [[
+But not all hope was lost.
+
+It was as Barius said. Another Heretical Forest
+was left in Ylva. Strangely, it was something
+that Saimore had created for research when
+still the Second Prince of Zanan.
+]]
+   },
+   {
+      "txt",
+      [[
+The country of Zanan which had led the attack on Vindale split,
+and the community of Rosuria, ruled by Barius, was born.
+
+Rosuria would cultivate the Forest, promote
+peace, and without regard for borders allow
+people to visit the Forest and be cured of
+their disease.
+]]
+   },
+   {
+      "txt",
+      [[
+The promised land of Rosuria was expected
+to become the utopia of Ylva.
+]]
+   },
+   {
+      "txt",
+      [[
+-Three Years Later-
+]]
+   },
+   {
+      "txt",
+      [[
+You have wandered from country to country, and
+like the first time you visited North Tyris, have
+slipped upon a merchant ship headed for Port Kapul.
+]]
+   },
+   {
+      "txt",
+      [[
+Three years have brought many changes.
+
+The scars left on Ylva are deep. Although
+the sadness may never be overcome, over
+time, the towns regained their bustle
+and the people have forgotten the nightmare,
+or at least behave as if they have.
+]]
+   },
+   {
+      "txt",
+      [[
+Rosuria has become corrupted.
+
+With the salvation they offered, Rosura attracted
+great wealth as well as the interest of many countries
+like the Yerles, and Rosuria was left at their mercy.
+
+Even with the world headed towards destruction,
+Ylva could not be united under Rosuria. With
+each country plotting and planning, new dark
+clouds of dispute have begun to cover Ylva.
+]]
+   },
+   {
+      "txt",
+      [[
+And now, your journey into the shadow of
+confusion covering Ylva is about to begin.
+]]
+   },
+   {
+      "txt",
+      [[
+You spent a great deal of time deciphering the
+writing of truth discovered in Lesimas, and
+discovered that between the era of Rehm-Ido
+and the previous civilization an unknown era
+known as Naku Domara existed.
+
+It was in this time that Chaos and magic were brought
+to Ylva, as well as the time that holds the keys to
+the mysterious civilization of Nefia.
+]]
+   },
+   {
+      "txt",
+      [[
+As you land in Port Kapul, the nostalgic cool
+winds of North Tyris brush against your face.
+You take a step forward.
+]]
+   },
+   {
+      "txt",
+      [[
+In your future, a wondrous yet difficult
+adventure concerning the Eternal League
+of Nefia awaits.
+]]
+   },
+   {
+      "txt",
+      [[
+Eternal League of Nefia
+<<Part 1 END>>
+]]
+   }
+}
+
+local story_15 = {
+   {
+      "actor", 1,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   {
+      "actor", 2,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   {
+      "actor", 3,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   { "mc", "elona.unrest2" },
+   { "pic", "base.bg6" },
+   {
+      "txt",
+      [[
+Meanwhile, at the camp of the Prince of Zanan.
+]]
+   },
+   {
+      "chat", 1,
+      "No need to be so tense, Elea. I have no intention of harming you. I simply wish for a conversational partner. Someone to talk to about myself."
+   },
+   {
+      "chat", 3,
+      "Someone to talk to? Don't expect for us to reach some sort of understanding. You're slyly manipulating the public opinion in order to call for the destruction of the Vindale Forest. Until you can provide some evidence that the issue of the Forest and the Ether Winds are the cause of the calamity of which you speak, the Elea will never believe you."
+   },
+   {
+      "chat", 1,
+      "There's no need for you to believe me. In fact, my story is a lie. Rather than being the cause of the calamity, the Vindale Forest is an antidote of sorts. It senses the revival of the Meshera and is releasing an antibody which we know as Ether."
+   },
+   {
+      "chat", 3,
+      "...What are you saying?"
+   },
+   {
+      "chat", 1,
+      "Fufu, got your attention now do I? But I'm afraid you'll have to listen to my tale before I inform you of the truth of the Forest."
+   },
+   {
+      "chat", 3,
+      "..."
+   },
+   { "mc", "elona.psml035" },
+   { "wait" },
+   {
+      "chat", 1,
+      "This story is from long ago. There were once two princes in Zanan. One was a frail and ugly albino, while the other was his handsome and vigorous brother Clyne. The name of the first, I think, need not be mentioned. The two princes were as different as light and shadow. The warlike Clyne was naturally successful, while his brother who lived in his shadow was a failure."
+   },
+   {
+      "chat", 1,
+      'Unlike his brother, the younger boy despised conflict, instead preferring song and poem. He was a pacifist and did much to help the disadvantaged and those that were orphaned by the war. Among these, he took a particular interest in the "Heretical" Elea and their Forest. While Clyne amused himself with hunting and socializing, the younger boy devoted himself to studying the Forest. Hope, after all, is something born of ignorance. Perhaps it was that he saw something of himself in the Heretical Forest. By eliminating the prejudice and suspicion regarding the Forest, and by exploring a path of coexistence with the Elea, he believed the world might change...'
+   },
+   {
+      "chat", 1,
+      "And yet years passed while his research made little progress. Fufu, the boy simply could not come to terms with the life of an adult. He couldn't accept that the world was at its core an unkind and unfair place where the strong rule over the weak. He began to begrudge his brother who continuously rose in power, all the while cursing himself for being born an albino and hating the world that refused to change its ways... And then, he met an angel."
+   },
+   {
+      "chat", 1,
+      "She was an Elean girl roughly his own age. From the moment he saw her he was fascinated with her. Her chestnut eyes were strong, gentle, and overflowing with compassion. As he watched her live a strong life in Zanan which is notoriously cruel to her kind, he once again saw a part of himself in the Elea."
+   },
+   {
+      "chat", 1,
+      "For the boy, she was... No, I think that's a story for another time... Suffice it to say that her passing left nothing but a gaping wound upon the boy's heart. Even now I am pained by my memories of that time... Let's continue this later. There is more than enough time to discuss everything."
+   }
+}
+
+local story_16 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "Sevilis' Subordinate",
+      portrait = "elona.man19"
+   },
+   {
+      "actor", 6,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "mc", "elona.lonely" },
+   { "pic", "base.bg2" },
+   {
+      "txt",
+      [[
+Meanwhile, in the bar in Derphy.
+]]
+   },
+   {
+      "chat", 3,
+      "Hoh, so you came without your subordinates. Don't expect me to forget that you're our \"lifeline\" with Zanan though."
+   },
+   {
+      "chat", 1,
+      "Zanan itself has nothing to do with all of this. The girl's confinement is a direct order from Saimore. From what I understand though, he's ready to release her at any time."
+   },
+   {
+      "chat", 4,
+      "And what does Saimore want in return?"
+   },
+   {
+      "chat", 1,
+      "Very soon the leaders from various countries will be gathering in Palmia for discussion. His request is that she attend as a representative of the Elea."
+   },
+   {
+      "chat", 3,
+      "...That's it? That kind of opportunity is something we've been desperately hoping for. What would he stand to gain from this?"
+   },
+   {
+      "chat", 1,
+      "If his intent was simply to arrest you all, there were innumerable methods he could have chosen. I'm sure Saimore has some twisted event planned... something he'll find humorous."
+   }
+}
+
+local story_17 = {
+   {
+      "actor", 1,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   {
+      "actor", 2,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   {
+      "actor", 3,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   { "mc", "elona.psml035" },
+   { "pic", "base.bg6" },
+   {
+      "txt",
+      [[
+Meanwhile, in Saimore's camp.
+]]
+   },
+   {
+      "chat", 1,
+      "I'm sure you've heard about the funeral of the late Prince Clyne, yes? Twas a grand affair, after all. Yet, few people are aware that there was no corpse within his coffin. The world was told that Clyne's death was a result of falling off a cliff while out on a ride... But that's not the truth. Would you care to take a guess at what is? Clyne was murdered. Murdered by that albino boy that everyone despised."
+   },
+   {
+      "chat", 1,
+      "As Clyne took in the view from the mountainside, his brother pushed him off the cliff. And when he made that push, something within him died as well. Having struggled his entire life to not be a burden on others, it was the first time the boy felt powerful and free. And yet in that moment, in his lust to deny and overturn the values of his brother whom the world viewed as a success, he abandoned himself. His pacifism, his compassion for the poor, his affection for the weak, all of the morals he touted - he betrayed them all and became nothing more than a tool for the power he had despised all his life."
+   },
+   {
+      "chat", 1,
+      "And even after becoming the successor to Zanan, he was unable to move forward. Oh, he could exercise his power and become a second Clyne if he so wished. But could he truly deny everything he once was? His past self that was so ugly and weak? Could he honestly turn his head, pretending that the pain and conflict that he and others had experienced each and every day did not exist? It was the very means by which I affirmed myself that also took away my ability to accept the world. Morals, values, emotions... What had I left to believe in? But don't misunderstand. I am not attempting to garner your sympathy by making it appear that I am unhappy or feel regret."
+   },
+   {
+      "chat", 3,
+      "Why tell me your story, then? To be honest, the choices you have defined for yourself appear as simple deception to me. Could that boy from the past who preached compassion towards the weak truly accept becoming such an ugly person as you are now? I won't say that I don't understand your pain. But having been rejected by the world - No, I should say having turned your back on it - and running from a life you felt incomplete, wishing nothing but pain and hatred upon yourself... I can't help but wonder if you're using these things to fill the emptiness in your heart."
+   },
+   {
+      "chat", 3,
+      "You say you had nothing left to believe in, but I feel that potential still lies within your heart. I think you have decided that some things are undeserving of love, and that you yourself are one of them. But I think that relationships can be built with methods others than hatred and insincerity."
+   },
+   {
+      "chat", 1,
+      "...How surprising. It is once again a young Elean girl that offers me the light known as hope as I drown within the darkness of my despair. But I'm afraid that the time where that may have been useful has passed. If nothing else, I now understand that if such a thing as good will existed within this world that there may have yet been another path for me. For that, at least, I am grateful."
+   },
+   {
+      "chat", 1,
+      "...Ah yes, I promised to tell you the secret of the Forest, didn't I? As you thought, the Ether Wind and the Forest's expansion are not the calamity known as the \"Meshera\". Meshera is... a bacteria, so to speak, that devours all life. It all but perished once during the era of Rehm-Ido, but has risen again with the advent of Sierra Terre. Or perhaps I should say that Sierra Terre is Meshera itself. The World-Devouring Giants live within me, within you, within all living creatures."
+   },
+   {
+      "chat", 3,
+      "But... If that's the case, if we're all infected by the Meshera, how are we alive?"
+   },
+   {
+      "chat", 1,
+      "I can't spoil the fun by giving everything away, now can I? I'll answer your question as strictly as I can. The reason that we can exist is due to the Heretical Forest. Were the Forest to be destroyed, all life on Ylva would disappear, though whether it would take a single year or a hundred I cannot say. Fufu. \"Heretical Forest\" is such an ironic name. It is we who are the true heretics of this world."
+   },
+   {
+      "chat", 1,
+      "Now it's only a matter of time before the Vindale Forest is destroyed by human hands. When everything that the people of the world believe in collapses, when they learn the truth too late to reverse their actions, what do you think will become of the world? I, for one, am looking forward to finding out."
+   },
+   {
+      "chat", 3,
+      "This is absurd. While I could sympathize with your background, how could you escalate a personal issue to one of life and death for the entire world?"
+   },
+   {
+      "chat", 1,
+      "Ah, but is it not that absurdity that makes it enjoyable? If you would prefer to discuss philosophy, speak with Barius instead. His own motivations differ from my own... But this conversation is at an end. Rest well, Witch of the Heretical Forest. I have an amusing scenario planned for you tomorrow."
+   }
+}
+
+local story_2 = {
+   {
+      "actor", 1,
+      name = "<Loyter> The Crimson of Zanan",
+      portrait = "elona.loyter"
+   },
+   {
+      "actor", 2,
+      name = "Soldier",
+      portrait = "elona.man19"
+   },
+   {
+      "actor", 3,
+      name = "????",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.town1" },
+   { "pic", "base.bg2" },
+   {
+      "txt",
+      [[
+- At the bar in Vernis -
+]]
+   },
+   {
+      "txt",
+      [[
+With the ringing cups of the Zanan soldiers, the bar in Vernis had at long last
+regained its liveliness.
+
+A young soldier, overwhelmed with liquor and drunk with his own sense of power,
+fabricated some pretext to begin a fight with a seedy-looking patron, occasionally
+yelling and striking the man with his fists.
+
+A red-haired official, noticing the commotion that his subordinate was causing,
+drained his tankard of Crim Ale and stood up calmly.
+
+]]
+   },
+   {
+      "chat", 1,
+      "What's going on here?"
+   },
+   {
+      "chat", 2,
+      "Oh, captain. Ain't nothing serious. Just questioning this suspicious looking man here. With the Prince in the area, a guard can't just overlook suspicious people even while at the bar! ...Hey, you. Are you listening?"
+   },
+   {
+      "chat", 3,
+      "..."
+   },
+   {
+      "chat", 1,
+      "This man is..."
+   },
+   {
+      "chat", 2,
+      "Yeah, as you can see, he's not much for manners. I'll just rough him up a bit more and then send him away. I couldn't possibly enjoy my drink now if I don't cause him at least some pain."
+   },
+   {
+      "chat", 1,
+      "Stop."
+   },
+   {
+      "chat", 2,
+      "C'mon Captain. If I break one of his legs, it'll just give the beggar an easier time."
+   },
+   {
+      "chat", 1,
+      "Whose benefit do you think I said that for? This man is the White Hawk of Zanan. Leave us alone for a while."
+   },
+   { "fade" },
+   { "mc", "elona.memory" },
+   { "fadein" },
+   {
+      "chat", 1,
+      "So this is where you holed up, is it? What, did you intend to become some type of hermit?"
+   },
+   {
+      "chat", 3,
+      "..."
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "You've changed. The White Hawk of Zanan, given the privileges of an aristocrat, whose talent was envied and whose deeds were praised by all, now sits in the corner of a rundown bar, gazing at the world with the eyes of a dead man. It was troubling, you know, to no longer have anyone to compete with once you left Zanan."
+   },
+   {
+      "chat", 3,
+      "..."
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "Heh, not even a single response to all of that. When you're bored of this little act, do you ever think back to what you told me back then?"
+   },
+   {
+      "chat", 1,
+      "You've been stripped of your fame and wealth and look like nothing more than a common beggar. What an unimaginable joke you are now compared to what you once were. Did you decide, perhaps, to cast off your desires and live the life of a sinner as a memorial to that girl?"
+   },
+   {
+      "chat", 3,
+      "I don't want to hear it."
+   },
+   {
+      "chat", 1,
+      "That Elean lass... Elishe, was it? If you'll allow me to borrow your own words here, wasn't even she just a part of your mask?"
+   },
+   {
+      "chat", 3,
+      "I have no intention of playing twenty questions with you. I'd rather be beaten and thrown into prison than answer your questions."
+   },
+   {
+      "chat", 1,
+      "As you request then, Bethel Rumford. It seems you've become soft. Any danger you may have posed has long since left you."
+   },
+   { "fade" }
+}
+
+local story_24 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "Soldier",
+      portrait = "elona.man19"
+   },
+   {
+      "actor", 6,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "pic", "base.bg6" },
+   { "mc", "elona.town4" },
+   {
+      "txt",
+      [[
+Meanwhile, at Palmia Castle.
+]]
+   },
+   {
+      "chat", 3,
+      "What an odd time to hold an audience. Does Saimore really intend to release Larnneire?"
+   },
+   {
+      "chat", 1,
+      "...Who knows. You can't trust what that man says."
+   },
+   {
+      "chat", 3,
+      "You bastard, you're the one who said..."
+   },
+   { "wait" },
+   { "se", "base.door1" },
+   { "wait" },
+   {
+      "chat", 2,
+      "...Lomias, Sevilis! I'm relieved to see that you're safe."
+   },
+   {
+      "chat", 3,
+      "Larnneire! We were worried about you! Did he do anything to you?"
+   },
+   {
+      "chat", 2,
+      "No, nothing. All he did was make me listen to him. But more importantly, I think we'd better get out of here. I have a bad feeling that something is about to happen."
+   },
+   { "wait" },
+   { "se", "base.door1" },
+   { "mc", "elona.pinch2" },
+   {
+      "chat", 5,
+      "There she is! The assassin!"
+   },
+   {
+      "chat", 3,
+      "What's going on, Larnneire?"
+   },
+   {
+      "chat", 5,
+      "She has others with her too. Call for reinforcements and establish a perimeter around the castle."
+   },
+   {
+      "chat", 1,
+      "...Heh, so that's why. We were called here to be framed as assassins. And most likely, the one who was killed is..."
+   },
+   {
+      "chat", 2,
+      "No... King Xabi..."
+   },
+   {
+      "chat", 4,
+      "We haven't been surrounded just yet. We can still escape."
+   },
+   {
+      "chat", 1,
+      "I trust Bethel if he says we can still escape. But if we're leaving, we have to do it now."
+   },
+   {
+      "chat", 3,
+      "I am so sick of Saimore's schemes. When will we ever be free of his plotting?"
+   }
+}
+
+local story_25 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.lonely" },
+   { "pic", "base.bg9" },
+   {
+      "txt",
+      [[
+Meanwhile, on the outskirts of Vernis.
+]]
+   },
+   {
+      "chat", 3,
+      "It's no use. We can't enter Vernis. The city is already abuzz with rumors about a Witch from the Heretical Forest using wicked magic to murder the king of Palmia for refusing to support Vindale."
+   },
+   {
+      "chat", 1,
+      "Saimore's aim is clear. By making us public enemies, he will drive us to the Heretical Forest and use that as an excuse for war."
+   },
+   {
+      "chat", 3,
+      "War, is it? The Elean people have neither the weapons nor stupidity required for such a thing. But if even avoiding conflict and secluding ourselves within the Forest leads to such distrust, what else is left to us?"
+   },
+   {
+      "chat", 2,
+      "Even if that's what Saimore plans, we still must go to the Forest to warn everyone. But I think we should make another stop first. Saimore told me to seek his research institute if I wanted to know more about the secrets of the Forest."
+   },
+   {
+      "chat", 3,
+      "And you intend to just do what he says?"
+   },
+   {
+      "chat", 2,
+      "He claimed that the Vindale Forest is keeping the Meshera in check. Obtaining evidence of that might just be the only hope we have left. And... I don't know quite how to say it, but I feel like he's waiting. He's waiting to see what path we will choose."
+   },
+   {
+      "chat", 1,
+      "Then we head for Zanan. Been a long time hasn't it, Bethel?"
+   },
+   {
+      "chat", 4,
+      "..."
+   }
+}
+
+local story_26 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.psml515" },
+   { "pic", "base.bg4" },
+   {
+      "txt",
+      [[
+Meanwhile, on a boat headed towards Zanan.
+]]
+   },
+   {
+      "chat", 1,
+      "I can't seem to fall asleep. Just what is it you're looking for out there?"
+   },
+   {
+      "chat", 2,
+      "Oh, Sevilis... I'm just thinking about the people Lomias and I left at the Forest. We left shouldering everyone's expectations. I was looking forward to seeing their smiling faces when we returned, but... This journey has become so long and painful. I'm truly sorry we got you involved in this. And I'm grateful you prepared this ship for us."
+   },
+   {
+      "chat", 1,
+      "There's no need to thank me. I have my own grudge against Zanan. I'm here of my own free will... And Bethel, too, has his own reasons for coming."
+   },
+   {
+      "chat", 2,
+      "You seem to know him... Bethel is a good man, I think. He seemed difficult to approach at first, but he has risked his life to protect us, and given us encouragement through our hardships. Even Lomias of all people has changed how he feels about him. But that smile he wears seems sad for some reason. It makes it seem... Like he's given up. Sometimes it feels like he's wearing a mask to hide his heart from other people."
+   },
+   {
+      "chat", 1,
+      "Some people don't mesh well with this world. Yes, he has his own problems, and he knows better than anyone else that he's the only one who can deal with them. But he can't bring himself to seek the sympathy and consolation of others. Some people will cling to and fight for and glimmer of hope that shows itself, while others will surrender and wallow in darkness. Which Bethel will choose, I cannot say."
+   }
+}
+
+local story_28 = {
+   {
+      "actor", 1,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   { "pic", "base.bg7" },
+   { "mc", "elona.memory2" },
+   {
+      "txt",
+      [[
+Meanwhile, in camp.
+]]
+   },
+   {
+      "chat", 1,
+      "Still awake, huh?"
+   },
+   {
+      "chat", 2,
+      "Bethel... I'm just thinking. About the Forest, about the Ether Wind, about what Saimore is expecting, about our journey... I can't say I've found any answers though."
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "Standing there like that... You remind me of Elishe."
+   },
+   {
+      "chat", 2,
+      "You've mentioned her before. Is she someone important to you?"
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "Like you, she was an Elea from Vindale. While we weren't blood related, we loved and supported one another like family while we lived in the port city of Altiheit in Zanan... I should stop. I'm sure this is boring for you."
+   },
+   {
+      "chat", 2,
+      "No, please continue. I'd like to hear about it."
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "...At the time, the war between the Yerles and the Eulderna was in full force, and many people got caught in the middle. I was still young, and the war had left me with nothing but disappointment and a feeling of emptiness. All I cared about was getting away from my home town, so I slipped aboard a ship carrying war orphans to Altiheit. It was there, in Altiheit, that I met Elishe."
+   },
+   {
+      "chat", 1,
+      "They looked at her with nothing but contempt, and their words towards her were nothing but abuse. They blamed her for an illness that had been spreading throughout the ship, and consequently, no orphanage would take her in. But Elishe stood strong and endured their abuse and contempt, as if that kind of treatment was normal for her. Before I even realized what I was doing, I was standing in front of her and holding her hand."
+   },
+   {
+      "chat", 1,
+      "Scrounging up enough to eat isn't easy for two children living alone in an unfamiliar city. But we took shelter in one of the port warehouses, and by working, managed to stave off hunger. While I worked for her sake, I found that my disappointment slowly began to fade. And then... Something strange happened."
+   },
+   {
+      "chat", 1,
+      'A leather bag began to be placed in the window of the warehouse every morning on the day of worship. Inside was hard bread and good cheese, a few gold coins, and occasionally even medicine or clothing. Someone was lending us a helping hand from the shadows. I once asked the man who brought the bag about it, but he dodged my question by saying it was from "The Fairy of Altiheit".'
+   },
+   {
+      "chat", 1,
+      "Whether that man was the \"fairy\" himself or simply a courier, I never found out. But I'm sure whoever it was noticed that it wasn't just bread or coin that bag brought us, but hope. Elishe and I clung to that faint light of hope and used it to weather our difficulties in Altiheit..."
+   }
+}
+
+local story_29 = {
+   {
+      "actor", 1,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   { "pic", "base.bg7" },
+   { "mc", "elona.memory2" },
+   {
+      "chat", 1,
+      "Before I left for Altiheit, I was enrolled in a military academy called Ateran, a place for those who are exceptionally gifted to sharpen their talents even further. For the kind of people at Ateran, power is everything. To them, everyone else is an enemy, nothing more than tools to be used in order to get ahead. They show no hesitation in using the weak as stepping stones... And I was no different. Knowingly or not, whether they resisted or not, I harmed many people. I was an arrogant and ruthless man."
+   },
+   {
+      "chat", 1,
+      "One day I came down with a terrible illness and had to leave Ateran. Through the attentive care of my younger brother, my only remaining relative, I narrowly survived. But when I rejoined the world after two months of recovery, it seemed like an entirely different place."
+   },
+   {
+      "chat", 1,
+      "Suddenly, when others looked at me, it was if I could feel their malice and contempt. Even in the eyes of children, a person like me who had left Ateran was nothing but a piece of trash... Of course, they didn't actually feel that way. I was terrorizing myself by projecting my own way of thinking onto others. It wasn't until that moment that I realized just how ugly and totally devoid of humanity I was."
+   },
+   {
+      "chat", 1,
+      "...I tried to change myself. But regardless of any efforts I made to find inner pieace, even when I otherwise kept myself engaged, the part of me that had been trained in Ateran sneered at how pathetic I was, tempting me to return. Even now I doubt I've fully separated myself from the values that place instilled in me. I fought that side of myself for many years, and in the end, I had nothing but a feeling of emptiness and a desire to erase everything about myself. That's why I left home."
+   },
+   {
+      "chat", 1,
+      "Elishe was different from any person I had ever met. She was not a beautiful woman as you are, but her eyes... They saw everything as it truly was, and forgave it. Accepted it... You have those eyes as well. The years I spent together with her in Altiheit will forever occupy a large place in my heart. Elishe was my reason to live, in every sense of the phrase."
+   },
+   {
+      "chat", 1,
+      "In order to protect her, in order to make her happy, I was able to accept my past self. By telling myself it was for her, I was capable of using others as tools and doing terrible things to guarantee success. My internal struggle had been entrusted to Elishe. And, after more than seven years in Altiheit, I had become a top officer in Zanan..."
+   }
+}
+
+local story_3 = {
+   {
+      "actor", 1,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   {
+      "actor", 2,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   {
+      "actor", 3,
+      name = "Soldier",
+      portrait = "elona.man19"
+   },
+   { "mc", "elona.unrest2" },
+   { "pic", "base.bg6" },
+   {
+      "txt",
+      [[
+Meanwhile, at the camp of the Prince of Zanan.
+]]
+   },
+   {
+      "chat", 3,
+      "Lord Saimore, we've arrested a strange man in the city tavern. According to Sir Loyter, he's the <White Hawk> that disappeared three years ago."
+   },
+   {
+      "chat", 1,
+      "Are you certain?"
+   },
+   {
+      "chat", 3,
+      "Hah, well... There is a passing resemblance, but his appearance is drastically different and he has refused to answer any of our questions. I would say it's a different person myself, but if Sir Loyter says it's him, then I trust his judgment."
+   },
+   {
+      "chat", 1,
+      "Changed, has he? Fufu... Of course he has. It's impossible that he'd be the same as he was before. Let him be. Do not harm him."
+   },
+   {
+      "chat", 3,
+      "As you wish, Lord Saimore."
+   },
+   { "wait" },
+   {
+      "chat", 1,
+      "How ironic. We searched for you ever since the time you left Zanan, and yet only now that things have progressed so far do we finally find you."
+   },
+   {
+      "chat", 2,
+      "The White Hawk of Zanan... What could you possibly expect from him at this point?"
+   },
+   {
+      "chat", 1,
+      "I expect nothing but that he shall live and bear witness to the comedy that shall soon unfold. Without that man, my story cannot come to a close."
+   },
+   { "fade" }
+}
+
+local story_30 = {
+   {
+      "actor", 1,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   { "mc", "elona.memory" },
+   { "pic", "base.bg7" },
+   {
+      "chat", 1,
+      "On that day... It was a cool Autumn night. I had gone to see a play together with Elishe. It was mediocre in every sense, but I can still remember it even now. There's nothing about that day I can forget."
+   },
+   {
+      "chat", 1,
+      "As we made our way home from the play, smoke and screams arose from a nearby mansion. We rushed over as quickly as we could, and when we arrived, the flames were still low. We immediately set about rescuing people. Elishe refused to stop until she could be certain nobody was left inside, until no more voices were crying out. And... A part of the exit-way suddenly collapsed on her..."
+   },
+   {
+      "chat", 1,
+      "I immediately rushed to her and attempted to lift the beam off of her, but it was impossible for me to do by myself. I turned to seek help from those around us, but my pleas were met only by the scared and cruel gazes of the onlookers. They were going to leave the young Elean girl who had been their savior to die. But what right had I to fault them? If a rival had needed my help, my reaction would have been the same as theirs... Before long, the flames had engulfed everything."
+   },
+   {
+      "chat", 1,
+      "I buried my head into the ground until dawn came. When I came across Elishe's bones when searching that charred rubble, I cried for the first time... And time has been frozen for me ever since."
+   }
+}
+
+local story_33 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "mc", "elona.unrest2" },
+   { "pic", "base.bg10" },
+   {
+      "chat", 3,
+      "So this is the institution that Saimore was talking about. Looks like it's been abandoned though. There doesn't appear to be anyone here, and the equipment doesn't seem to have been used recently either. I hope the information we came for is still here."
+   },
+   {
+      "chat", 5,
+      "I hate to be the bearer of bad news, but the \"evidence\" you're looking for isn't here."
+   },
+   {
+      "chat", 2,
+      "You..."
+   },
+   {
+      "chat", 5,
+      "Not that it matters. Even if you found the evidence you're looking for, who would listen to an Elea anymore? Oh, but don't worry. I haven't come to interfere with you. I came to tell you the truth about the Vindale Forest."
+   },
+   {
+      "chat", 3,
+      "And we should believe the words of someone who would betray his race, and our captor no less?"
+   },
+   {
+      "chat", 5,
+      "It's your choice whether or not to believe me. But there's no use in wasting your precious time on a plan that will bear no fruits. As someone with the blood of the Elea, I can sympathize with you."
+   },
+   { "mc", "elona.anosora" },
+   { "wait" },
+   {
+      "chat", 5,
+      "How much do you know about the civilization of Rehm-Ido? Rehm-Ido overcame the materialism that had plagued Eyth Terre, and even after 300 years was considered to be the greatest civilization of the world. All across the nation various communities were joined by the idea of mutual cooperation with each other and harmony with nature."
+   },
+   {
+      "chat", 5,
+      "Yet among these communities was a group that differed from the others, known as the Yutasu. Rather than being a close-knit community, \"Yutasu\" was simply a generic term for those who lacked the ability to fit in with the other communities. Those who couldn't form close bonds with others, those with abnormal desires, those who preferred solitude, those without morals, materialists... Anyone who didn't fit in with the other communities was named Yutasu, and while it wasn't visible on the surface, they were detested by society."
+   },
+   {
+      "chat", 5,
+      "The substance that we know as Ether was discovered by accident near the end of Rehm-Ido. Rehm-Ido had highly advanced biochemistry, and Ether proved to be a valuable resource that provided a chemical change to a variety of medicines. And perhaps most importantly, Ether could be harvested from trees and was environment friendly, a perfect fit for the ideology of Rehm-Ido."
+   },
+   {
+      "chat", 5,
+      'With the discovery of Ether came a great change in the position of Yutasu in society. The process of Ether collection was called "Star Harvesting" and considered sacred... And the Yutasu were the greatest land holders. Through the process of "Star Harvesting", the Yutasu regained their injured self-esteem and found their place in the society of Rehm-Ido. It was for this reason that, despite knowing it was coming, they averted their eyes from the creeping threat of the Meshera...'
+   },
+   {
+      "chat", 5,
+      "How the Meshera came to be remains a mystery. What is known is that it was Ether that was responsible for the immune system of the forests. With the rampant collection of Ether, the forests were left easy prey for the Meshera. Because the Yutasu were afraid of losing their status they had gained as Ether collectors, by the time the rest of the world noticed what was happening, it was too late to do anything."
+   },
+   {
+      "chat", 5,
+      'The forest "devouring" Meshera gradually spread, and where they spread, they created an environment where no other life on Ylva could survive. The civilization of Rehm-Ido was slowly slipping towards its death.'
+   }
+}
+
+local story_35 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "mc", "elona.anosora" },
+   { "pic", "base.bg10" },
+   {
+      "chat", 5,
+      'It was only the far East, where untouched forests still covered the land, that withstood the advance of the Meshera. The people gave the Forest the name of "Vindale", meaning hope... And after many years, after the vast knowledge and culture of the previous human civilization had been lost, the Vindale Forest lived up to its name.'
+   },
+   {
+      "chat", 5,
+      "A massive immune reaction arose from the Forest, becoming a wind that raged across the world. Indeed, this is what we now know as the Ether Wind. The Ether Wind enhanced the natural immunity of the plant life that had been infected by the Meshera, massively weakening the Meshera infection. The Vindale Forest which produced the Ether Winds and the outside world where the Meshera had been weakened slowly began to differ from one another. That is the environment present in Ylva now."
+   },
+   {
+      "chat", 5,
+      "With the arrival of the miracle of Vindale, the civilization of Rehm-Ido came to an end, and the era of Sierra Terre began... But humanity had painful times in their future. As time passed, some were born who could adapt to life outside of the Forest, and eventually, some who were born who were only capable of living outside the Forest. How that would turn out, you should well know."
+   },
+   {
+      "chat", 5,
+      "...That is the truth of the Forest. Should the Vindale Forest ever be destroyed, the Ether Winds will cease. Eventually the Meshera would spread across all of Ylva, leaving it a place unsuitable for life."
+   },
+   {
+      "chat", 3,
+      "So now we understand the truth of the Forest. And yet, now another question is even more difficult to grasp. What the hell is the meaning behind doing this? I could understand if the motive was revenge against those who had abused the Elea, but what point would such an action have if all life perishes as a result?"
+   },
+   {
+      "chat", 5,
+      "It is not revenge. It is both a punishment and a chance. Besides, life will not perish. Salvation is already within our grasp."
+   },
+   {
+      "chat", 5,
+      "I believe Rehm-Ido to be the ideal civilization. Yet, something as weak as fellowship isn't enough to keep the Yutasu in check. In order to overcome the Yutasu, the civilization must have a stronger and more precise will. When the time comes, you will understand. For this plan to succeed, the sacrifice of Vindale was required."
+   }
+}
+
+local story_4 = {
+   {
+      "actor", 1,
+      name = "<Xabi> The King of Palmia",
+      portrait = "elona.xabi"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   {
+      "actor", 4,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   { "mc", "elona.town4" },
+   { "pic", "base.bg5" },
+   {
+      "txt",
+      [[
+Meanwhile, in the throne room of Palmia.
+]]
+   },
+   {
+      "chat", 1,
+      "It's wonderful to see you again, Larnneire. You have grown from a naughty little child into a splendid woman since last we met. I'm sure your journey here must have been harsh, given the circumstances."
+   },
+   {
+      "chat", 2,
+      "It's been a long time, Your Majesty. Thanks to your influence, we were able to arrive here without incident. At this time, as a messenger from the Forest, and for the sake of both the Elea and all of Sierra Terre, I would like to request that Palmia lend the Elea its strength in dealing with the Heretical Forest."
+   },
+   {
+      "chat", 1,
+      "...Larnneire, I am truly sorry, but I'm afraid that I cannot lend you that aid that you seek. I too am pained by the tragedy befalling the Elea, but as I'm sure you're aware, the most Palmia can do is seek to keep a balance between the Yerles and the Eulderna."
+   },
+   {
+      "chat", 1,
+      "The Prince of Zanan has already gathered significant support from various nations and their peoples, and they have found a common enemy in the Heretical Forest. If Palmia were to speak against this now, not only would Zanan treat us as rebels, but the two great nations would as well. If Palmia were to fall, there would no longer be any barrier against a war between the two great nations. I simply cannot condemn Sierra Terre to another great war."
+   },
+   {
+      "chat", 2,
+      "...Is your intent then for the Elea to be the sacrificial lambs on the altar of peace between the two great nations? Our country was only established because the blood of innocent Elea was being shed in foreign nations. What peace we have had has been short and fragile. Is there no longer anyone on this continent with the heart to reach out to the weak?"
+   },
+   {
+      "chat", 3,
+      "...If they committed no sin, then their fate is truly regrettable. Yet, surely you're aware of what your Heretical Forest and its Ether Winds have wrought upon the world?"
+   },
+   {
+      "chat", 2,
+      "So you've come, Lord Barius? Certainly it is undeniable that strange events have been occurring in the Forest due to the Ether Winds. But for what reason would the Vindale Forest, which has posed no problems for all of Sierra Terre, suddenly act up now? Is it not prejudice to lay blame at the feet of the Elea without first investigating?"
+   },
+   {
+      "chat", 2,
+      "Your Majesty, please heed my words. The issue of the Ether Winds and the Forest is not related to the calamity that they speak of. If the claims that the Prince of Zanan makes are wrong..."
+   },
+   {
+      "chat", 1,
+      "Speak no further, Larnneire."
+   },
+   {
+      "chat", 2,
+      "But Your Majesty, the truth..."
+   },
+   {
+      "chat", 1,
+      "I said that's enough. I'll hear the rest of what you have to say tomorrow. I will have arrangements made for you and your companion to stay tonight at the inn. Now is... not the time for us to continue. Please understand."
+   },
+   { "wait" },
+   {
+      "chat", 2,
+      "Your Majesty... Very well. But I will be back again tomorrow. You are the Elea's final hope."
+   },
+   { "fade" },
+   { "mc", "elona.soraochi" },
+   { "fadein" },
+   {
+      "chat", 4,
+      "How embarrassing. Don't believe the girl's lies, King Xabi."
+   },
+   {
+      "chat", 4,
+      'I began investigating this disaster at a young age. The "Meshera" are also known as the "World Devouring Giants". Is the Heretical Forest, whose roots spread and eat away our lands, not exactly that? Even were her claims that the Forest and the Meshera are unrelated to be true, it is undeniable that the Forest is consuming our land and producing terrible monsters. King Xabi, I must insist that you entrust that girl to my care.'
+   },
+   {
+      "chat", 1,
+      "Hmm. Could that be because what Larnneire speaks is the truth?"
+   },
+   {
+      "chat", 4,
+      "What I have told you is the truth. I have my own interests in that girl. More importantly, King Xabi, have you forgotten that Palmia's existence is reliant upon Zanan?"
+   },
+   {
+      "chat", 1,
+      "Larnneire is an important guest. Even if the request is coming from the Prince of Zanan himself, I cannot hand her over. Palmia will forsake all involvement with the issue of the Vindale Forest. Is that not enough to satisfy you? You must excuse me for now. I have other business that must be attended to."
+   },
+   { "wait" },
+   {
+      "chat", 4,
+      "...Fufu, she escaped. Still, I was surprised. Is she not the spitting image of her?"
+   },
+   {
+      "chat", 3,
+      "First the White Hawk, and now her. At last the wheels of destiny have begun to turn."
+   },
+   {
+      "chat", 4,
+      "While I don't believe in fate, this lively stage that has been set has exceeded my expectations. I welcome it. We must prepare a suitable role for them. I have faith in your abilities, Barius The Blue Haired."
+   },
+   {
+      "chat", 3,
+      "..."
+   },
+   { "fade" }
+}
+
+local story_40 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.lonely" },
+   { "pic", "base.bg9" },
+   {
+      "chat", 4,
+      "Sevilis, there's something I've been meaning to ask you. How is it that you know me?"
+   },
+   {
+      "chat", 1,
+      "...I once wore the name of Clyne. Is that name familiar to you? The heir of Zanan, and the man Saimore killed."
+   },
+   {
+      "chat", 4,
+      "Then you are the true King of Zanan? ...Interesting. But that doesn't answer my question."
+   },
+   {
+      "chat", 1,
+      "A single girl was the trigger of everything. A light rain was falling in Altiheit, scattering the streetlight as it fell to the earth. A group of people surrounded and gazed cruelly at a young Elean girl, and a beautiful blonde young man protected her without hesitation. From that moment, he was like her brother... That event became Saimore's hope, and the White Hawk became the target of his admiration."
+   },
+   {
+      "chat", 4,
+      "Elishe..."
+   },
+   {
+      "chat", 1,
+      "Saimore wished for the two of you to live a happy life... And so he helped. You should know well that, even in a merit-based society like Zanan, without some sort of connection it's difficult to realize the dream of become an Officer of the Imperial Court while associating with an Elean girl."
+   },
+   {
+      "chat", 4,
+      "...The Fairy of Altiheit... was Saimore..."
+   }
+}
+
+local story_5 = {
+   {
+      "actor", 1,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 2,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 3,
+      name = "????",
+      portrait = "elona.liana"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.psml515" },
+   { "pic", "base.bg2" },
+   {
+      "txt",
+      [[
+Meanwhile, at the bar in Palmia.
+]]
+   },
+   {
+      "chat", 2,
+      "We're looking for a woman named Liana. Do you know of her?"
+   },
+   {
+      "chat", 3,
+      "...And what business do you have with her?"
+   },
+   {
+      "chat", 2,
+      "We've been told that she'll fulfill any request, so long as the price is right. While I don't feel as if we need one, we were instructed to seek out Liana by the King so that we may hire a guard."
+   },
+   {
+      "chat", 3,
+      "Any request for a price, is it? ...Fufu. Well, I certainly know someone who is skilled enough to help you, regardless of what danger it is you find yourself in. But for that man, it comes down to whether he feels like it or not, not a price. Yes, I am Liana. Both of you, come with me."
+   },
+   { "fade" },
+   { "pic", "base.bg8" },
+   { "fadein" },
+   {
+      "actor", 3,
+      name = "<Liana> The Girl of Fancies",
+      portrait = "elona.liana"
+   },
+   {
+      "chat", 3,
+      "Bethel, I've finally got some work for you... *cough* *cough*"
+   },
+   { "wait" },
+   {
+      "chat", 3,
+      "You barely eat, and yet here you are inhaling crimberry smoke. My precious Bethel... Come now, stand up. You need to greet the clients."
+   },
+   {
+      "chat", 2,
+      "Oh, wonderful. The sword master we're supposed to rely on for protection is a drug addled mess. Larnneire, this is pointless. Regardless of what skill this man may have had, we don't have time for him to sober up."
+   },
+   {
+      "chat", 3,
+      "Now now... there's no need to be in such a rush. Don't mind them, Bethel. These people don't know the terrible things that you've been through. When I first saw your haunted eyes, I knew. This man has known unimaginable suffering. He's a pitiful man that can't let go of his past. But as long as he sticks with me, I'm sure I'll be able to help him overcome that. But you know, Bethel... If you don't work, you can't eat!"
+   },
+   {
+      "chat", 4,
+      "Starving to death with you wouldn't be a bad way to go."
+   },
+   {
+      "chat", 3,
+      "Oh Bethel, you flatterer!!"
+   },
+   {
+      "chat", 4,
+      "Fufu. Liana, I don't plan on taking you with me to the next world. Now, the request..."
+   },
+   {
+      "chat", 4,
+      "...Elishe...?"
+   },
+   {
+      "chat", 1,
+      "Elishe?"
+   },
+   {
+      "chat", 4,
+      "No, never mind. Tell me about your request."
+   },
+   {
+      "chat", 2,
+      "There'll be no need for that. Let us just consider the order to hire a drug addled bodyguard a poor Palmian joke. I don't recall there being anyone out to get us anyway."
+   },
+   {
+      "chat", 4,
+      "...The drugs may have dulled my senses, but I'm still easily capable of guarding you. And given the number of presences I can sense surrounding the place, I think you'll find you need someone of my caliber."
+   },
+   {
+      "chat", 1,
+      "This place is surrounded? Are they aiming for us?"
+   },
+   {
+      "chat", 4,
+      "We don't have time to stop and ask questions. Don't lose sight of me. We're going to leave the city through the alleyways."
+   },
+   { "fade" }
+}
+
+local story_60 = {
+   {
+      "actor", 1,
+      name = "<Saimore> The Crown Prince of Zanan",
+      portrait = "elona.saimore"
+   },
+   {
+      "actor", 2,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   {
+      "actor", 3,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 4,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 5,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   { "mc", "elona.lonely" },
+   { "pic", "base.bg7" },
+   {
+      "chat", 5,
+      "The border of Karune is in sight. If we keep a steady pace, we'll reach Vindale in three days."
+   },
+   {
+      "chat", 4,
+      "What do you intend to do after returning to the Forest? With our strength, even delaying the invasion by Zanan would be difficult, let alone stopping them."
+   },
+   {
+      "chat", 5,
+      "We will warn the people of the Forest. They may not have even realized the threat creeping towards them. After that, I don't know. Having our home destroyed is painful, yet part of me believes they should do as they damn well please. Those who took part in the Forest's destruction and those who stood on the sidelines and allowed it will realize with despair what they have wrought. But Larnneire... What do you think?"
+   },
+   {
+      "chat", 3,
+      "I can understand how you feel. But I want to stay true to myself until the end. I want to do everything I can to protect the Forest. Even if we fail, perhaps we'll leave a bud of hope that will live afterwards."
+   },
+   { "fade" },
+   { "pic", "base.bg5" },
+   { "mc", "elona.soraochi" },
+   { "fadein" },
+   {
+      "txt",
+      [[
+Meanwhile, at the Zanan Royal Household.
+]]
+   },
+   {
+      "chat", 1,
+      "How does it feel to destroy your home, Barius? The Eulderna are in Karune and can move at any time. They only wait for orders."
+   },
+   {
+      "chat", 2,
+      "...Our miscalculations led to the Yerles not participating. Much of the meaning of this war was to have the whole world involved. But, there won't be any interference with the invasion. Vindale isn't prepared for war."
+   },
+   {
+      "chat", 1,
+      "Once the Forest is gone, I leave things in your hands. I intend to hide, though with this body I'm sure I won't stay hidden long. But that's fine. As long as I can leave a scar on Ylva, I will be satisfied."
+   }
+}
+
+local story_7 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "Sevilis' Subordinate",
+      portrait = "elona.man19"
+   },
+   {
+      "actor", 6,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "mc", "elona.lonely" },
+   { "pic", "base.bg5" },
+   {
+      "txt",
+      [[
+Meanwhile, at the palace in Derphy.
+]]
+   },
+   {
+      "chat", 1,
+      "You're King Xabi's young female guest?"
+   },
+   {
+      "chat", 2,
+      "...Yes. My name is Larnneire."
+   },
+   {
+      "chat", 3,
+      "The cold-hearted shadow of Deprhy, Duke Sevilis. I recall the King once mentioning to rely on you in case of an emergency, and so we have come. Someone is after us, though we are unaware of their identity. Could you use your connections in the underworld to find out?"
+   },
+   {
+      "chat", 1,
+      "I see. You did well to rely on me. The ones pursuing you are from Zanan... Saimore, to be precise. Heh, there's no need to have anyone investigate that. Let's see, so we have both the girl and the White Hawk here. You've changed quite a bit since last I saw you, Bethel Rumford. Why is it you yet live with such regret?"
+   },
+   {
+      "chat", 4,
+      "I wasn't aware one needed a reason to continue living. And forgive me for my rudeness, Duke Sevilis, but I don't recall us having met before."
+   },
+   {
+      "chat", 1,
+      "Heh, I'm not surprised. You'd be unlikely to remember me with this face. We've both changed. Now, regarding your group's fate..."
+   },
+   { "wait" },
+   {
+      "chat", 5,
+      "Lord Sevilis, Sir Barius urges you to hurry."
+   },
+   {
+      "chat", 3,
+      "...Barius?"
+   },
+   {
+      "chat", 1,
+      "My apologies. As you've no doubt surmised, I was visited by another guest before your arrival. While I'm sure you're tired from your long trip from Palmia, Larnneire, I'll have to ask that you accompany him. Though, it's not really a choice. The palace is already surrounded."
+   },
+   {
+      "chat", 2,
+      "So you will hand me over to Zanan. Would you betray the trust of King Xabi so easily?"
+   },
+   {
+      "chat", 1,
+      "...Relax. Saimore will harm neither you nor your companions."
+   },
+   {
+      "chat", 4,
+      "You will regret this, Duke Sevilis. I will remember your betrayal, and I am a vindictive man."
+   },
+   { "fade" },
+   { "pic", "base.bg5" },
+   { "fadein" },
+   {
+      "chat", 1,
+      "This is enough, isn't it?"
+   },
+   {
+      "chat", 6,
+      "Yes. I appreciate your cooperation."
+   },
+   {
+      "chat", 1,
+      "Your methods are as dirty as ever, Barius. Do you intend to keep your promise?"
+   },
+   {
+      "chat", 6,
+      "Don't worry. Your subordinates have been treated courteously. I'll have them delivered at dawn... Oh yes, and I won't mention to Saimore that you're still alive. It would be quite the inconvenience if he were to find out, wouldn't it?"
+   },
+   {
+      "chat", 1,
+      "...Do as you like."
+   }
+}
+
+local story_70 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "<Lomias> The Messenger From Vindale",
+      portrait = "elona.lomias"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   { "mc", "elona.boss2" },
+   { "pic", "base.bg11" },
+   {
+      "chat", 3,
+      "...Look! There are flames in the Forest. Has Zanan already begun the invasion?"
+   },
+   {
+      "chat", 2,
+      "Hurry, Lomias! Head to the Forest! Those who were slow to get out or who stayed need to be evacuated."
+   },
+   {
+      "chat", 3,
+      "Got it. And you, Larnneire?"
+   },
+   {
+      "chat", 2,
+      "I will go to Saimore. It may gain us nothing to negotiate at this point, but even so, for the sake of the Elea who are evacuating... If nothing else, I'll earn them time."
+   },
+   {
+      "chat", 1,
+      "We will go with Larnneire. While the Forest still lives, we humans cannot enter."
+   },
+   {
+      "chat", 4,
+      "Don't worry, Larnneire. I won't allow any soldiers to lay a single finger on you before we reach Saimore."
+   }
+}
+
+local story_90 = {
+   {
+      "actor", 1,
+      name = "<Sevilis> The Fog of Derphy",
+      portrait = "elona.sevilis"
+   },
+   {
+      "actor", 2,
+      name = "<Larnneire> The Listener of the Wind",
+      portrait = "elona.larnneire"
+   },
+   {
+      "actor", 3,
+      name = "Soldier",
+      portrait = "elona.man19"
+   },
+   {
+      "actor", 4,
+      name = "<Bethel> The White Hawk",
+      portrait = "elona.bethel"
+   },
+   {
+      "actor", 5,
+      name = "<Barius> The Blue Haired",
+      portrait = "elona.barius"
+   },
+   { "mc", "elona.boss2" },
+   { "pic", "base.bg11" },
+   {
+      "chat", 5,
+      "My my, to what do I owe the pleasure of receiving a Witch of the Heretical Forest here?"
+   },
+   {
+      "chat", 2,
+      "Barius, why are you... Where is Saimore? Let me talk to him."
+   },
+   {
+      "chat", 5,
+      "He is no longer here, nor do I know where he has gone. I have taken command. And unfortunately for you, I have no intention of negotiating."
+   },
+   {
+      "chat", 2,
+      "I know it's too late to stop the flames. But please, stop attacking the Elea who are escaping the Forest. They don't even have weapons with which to resist."
+   },
+   {
+      "chat", 5,
+      "I said I would not negotiate. But I am different than him. If no one stands in the way of our goal, then there is no need for bloodshed."
+   },
+   { "wait" },
+   {
+      "chat", 3,
+      "Lord Barius, a distress signal has gone up from the Forest. I'm afraid a group got lost in the smoke, and after coming in contact with the Forest's miasma, is unable to escape."
+   },
+   {
+      "chat", 5,
+      "Inside the Forest? Fools... Leave them. The Forest is still alive. And don't bother me with every little message."
+   },
+   {
+      "chat", 2,
+      "...Tell me where the signal came from. I will help."
+   },
+   {
+      "chat", 5,
+      "Fufu, amusing. You intend to save those who burn your home and slaughter your kin?"
+   },
+   {
+      "chat", 4,
+      "This is unnecessary. Don't you hate them for what they're doing?"
+   },
+   {
+      "chat", 2,
+      "Let go of my arm, Bethel. It's precisely because of this situation that I must go. I must show that even for those who can't understand each other, you can't abandon the idea that possibilities exist beyond a simple wall of hatred and distrust."
+   },
+   {
+      "chat", 4,
+      "I am begging you... Please, Larnneire, don't go. If you enter the Forest, I won't be able to follow you. I won't be able to protect you. Will you once again carve the pain of that day into my heart?"
+   },
+   {
+      "chat", 2,
+      "If I abandon them here then I have betrayed myself, as well as the Elishe that you loved. I know that it cannot be only sorrow that she brought you. Goodbye, White Hawk of Altiheit. No matter how many tears you shed from the pain of the wounds upon your wings, I pray that the day will come that you will be able to fly once more."
+   }
+}
+
+return {
+   story_0 = story_0,
+   story_1 = story_1,
+   story_2 = story_2,
+   story_3 = story_3,
+   story_4 = story_4,
+   story_5 = story_5,
+   story_7 = story_7,
+   story_15 = story_15,
+   story_16 = story_16,
+   story_17 = story_17,
+   story_24 = story_24,
+   story_25 = story_25,
+   story_26 = story_26,
+   story_28 = story_28,
+   story_29 = story_29,
+   story_30 = story_30,
+   story_33 = story_33,
+   story_35 = story_35,
+   story_40 = story_40,
+   story_60 = story_60,
+   story_70 = story_70,
+   story_90 = story_90,
+   story_100 = story_100,
+}

--- a/src/mod/oo_en/data/scene/init.lua
+++ b/src/mod/oo_en/data/scene/init.lua
@@ -1,0 +1,12 @@
+local en = dofile("mod.oo_en.data.scene.en")
+
+local keys = table.keys(en)
+
+-- TODO immutable data edits
+for _, _id in ipairs(keys) do
+   local full_id = "elona." .. _id
+   local scene_proto = data["elona_sys.scene"][full_id]
+   if scene_proto then
+      scene_proto.content.en = en[_id]
+   end
+end

--- a/src/mod/oo_en/init.lua
+++ b/src/mod/oo_en/init.lua
@@ -1,0 +1,1 @@
+require("mod.oo_en.data.init")

--- a/src/mod/oo_en/mod.lua
+++ b/src/mod/oo_en/mod.lua
@@ -1,0 +1,7 @@
+return {
+   id = "oo_en",
+   version = "0.1.0",
+   dependencies = {
+      elona = ">= 0.1.0"
+   }
+}


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [x] Enhancement
- [ ] New feature

### Description

Adds a mod that modifies the story cutscenes to have the English translations from omake overhaul modify.

All credit for the translations goes to Doorknob.