### PR TITLE
Implement menu hiding in inventory proto callbacks

### DIFF
--- a/src/api/gui/menu/InventoryContext.lua
+++ b/src/api/gui/menu/InventoryContext.lua
@@ -184,6 +184,7 @@ function InventoryContext:init(proto, params, ctxt_params)
    self.show_target_equip = self.proto.show_target_equip
    self.shortcuts = self.proto.shortcuts
    self.stack = {}
+   self._is_menu_visible = true
 
    -- Valid parameters to pass in the `params` table.
    self.chara = params.chara or nil
@@ -371,6 +372,14 @@ function InventoryContext:on_menu_exit()
    end
 
    return "player_turn_query"
+end
+
+function InventoryContext:is_menu_visible()
+   return self._is_menu_visible
+end
+
+function InventoryContext:set_menu_visible(visible)
+   self._is_menu_visible = not not visible
 end
 
 return InventoryContext

--- a/src/api/gui/menu/InventoryMenu.lua
+++ b/src/api/gui/menu/InventoryMenu.lua
@@ -266,15 +266,11 @@ function InventoryMenu:on_select()
       return nil, canceled
    end
 
-   -- BUG: have some way of hiding the inventory window conditionally inside
-   -- on_select(). when the window was shown in vanilla and a prompt appeared
-   -- over it, the screen was not redrawn, which caused the window to be kept in
-   -- the screen's drawing buffer. if a directional prompt or similar which puts
-   -- the focus back on the tilemap was shown instead, the screen was refreshed
-   -- and the menu would not be redrawn, so it would become hidden.
-   self.is_drawing = false
    local result = self.ctxt:on_select(item, amount, self.pages:iter_all_pages():extract("item"))
-   self.is_drawing = true
+
+   -- Reset the visibility of the inventory menu if it was disabled by the
+   -- inventory_proto callbacks.
+   self.ctxt:set_menu_visible(true)
 
    return result
 end
@@ -463,7 +459,7 @@ function InventoryMenu:update_filtering(play_sound)
 end
 
 function InventoryMenu:draw()
-   if not self.is_drawing then
+   if not self.ctxt:is_menu_visible() then
       return
    end
 

--- a/src/mod/elona/data/inventory_proto.lua
+++ b/src/mod/elona/data/inventory_proto.lua
@@ -80,6 +80,7 @@ local inv_examine = {
    icon = 7,
    window_title = "ui.inventory_command.general",
    query_text = "ui.inv.title.general",
+
    on_select = function(ctxt, item, amount, rest)
       local list = rest and rest:to_list()
       ItemDescriptionMenu:new(item, list):query()
@@ -299,6 +300,7 @@ local inv_drink = {
       return item:calc("can_drink")
    end,
    on_select = function(ctxt, item)
+      ctxt:set_menu_visible(false)
       return ElonaAction.drink(ctxt.chara, item)
    end
 }
@@ -319,6 +321,7 @@ local inv_zap = {
    end,
    on_shortcut = fail_in_world_map,
    on_select = function(ctxt, item)
+      ctxt:set_menu_visible(false)
       return ElonaAction.zap(ctxt.chara, item)
    end
 }
@@ -609,6 +612,7 @@ local inv_use = {
       return item:calc("can_use")
    end,
    on_select = function(ctxt, item, amount, rest)
+      ctxt:set_menu_visible(false)
       return ElonaAction.use(ctxt.chara, item)
    end
 }
@@ -629,6 +633,7 @@ local inv_open = {
    end,
    on_shortcut = fail_in_world_map,
    on_select = function(ctxt, item, amount, rest)
+      ctxt:set_menu_visible(false)
       return ElonaAction.open(ctxt.chara, item)
    end
 }
@@ -702,6 +707,7 @@ local inv_dip = {
       return can_dip
    end,
    on_select = function(ctxt, item, amount, rest)
+      ctxt:set_menu_visible(false)
       return ElonaAction.dip(ctxt.chara, ctxt.params.dip_item, item)
    end
 }
@@ -808,6 +814,7 @@ local inv_throw = {
    end,
    on_select = function(ctxt, item, amount, rest)
       -- >>>>>>>> shade2/command.hsp:3957 		if invCtrl=26{	 ...
+      ctxt:set_menu_visible(false)
       local x, y, can_see = Input.query_position()
       if not can_see then
          Gui.mes("action.which_direction.cannot_see_location")

--- a/src/mod/weight_graph/advice/InventoryMenu_weight_graph.lua
+++ b/src/mod/weight_graph/advice/InventoryMenu_weight_graph.lua
@@ -48,6 +48,10 @@ local function get_proto_kind(ctxt)
 end
 
 function InventoryMenu_weight_graph.after:draw(...)
+   if not self.ctxt:is_menu_visible() then
+      return
+   end
+
    local ext = Extend.get(self, "weight_graph")
    if config.weight_graph.show_weight_graph ~= "disabled" and ext.enabled then
       ext.weight_graph:draw()


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

Closes #336.

### Description

Allows inventory prototypes to hide and show the menu programmatically. It should work for purposes of being able to play the game normally.