### PR TITLE
Advanced drawing APIs

### DIFF
--- a/src/api/Aspect.lua
+++ b/src/api/Aspect.lua
@@ -91,7 +91,7 @@ function Aspect.build_defaults_for(obj, aspect_opts)
    if aspect_opts then
       for iface, _opts in pairs(aspect_opts) do
          if is_aspect(iface) and not seen[iface] then
-            Log.error("Aspect arguments recieved for %s, but prototype '%s:%s' does not declare that aspect in its _ext table.", k, self._type, self._id)
+            Log.error("Aspect arguments recieved for %s, but prototype does not declare that aspect in its _ext table.", iface)
          end
       end
    end

--- a/src/api/Aspect.lua
+++ b/src/api/Aspect.lua
@@ -77,7 +77,7 @@ function Aspect.build_defaults_for(obj, aspect_opts)
          seen[k] = true
          local _params = (aspect_opts and aspect_opts[k]) or {}
          if type(v) == "table" then
-            _params = table.merge_ex(table.deepcopy(v), _params)
+            _params = table.merge(table.shallow_copy(v), _params)
 
             -- HACK it shouldn't be possible to deepcopy class tables
             if v._impl then
@@ -91,7 +91,7 @@ function Aspect.build_defaults_for(obj, aspect_opts)
    if aspect_opts then
       for iface, _opts in pairs(aspect_opts) do
          if is_aspect(iface) and not seen[iface] then
-            Log.error("Aspect arguments recieved for %s, but prototype does not declare that aspect in its _ext table.", iface)
+            Log.error("Aspect arguments received for %s, but prototype does not declare that aspect in its _ext table.", iface)
          end
       end
    end

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -51,6 +51,8 @@ Draw.set_logical_viewport = draw.set_logical_viewport
 
 Draw.set_logical_viewport_enabled = draw.set_logical_viewport_enabled
 
+Draw.is_logical_viewport_enabled = draw.is_logical_viewport_enabled
+
 
 --- @function Draw.get_width
 Draw.get_width = draw.get_width

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -39,10 +39,10 @@ Draw.run = draw.run
 
 
 --- @function Draw.get_width
-Draw.get_width = love.graphics.getWidth
+Draw.get_width = draw.get_width
 
 --- @function Draw.get_height
-Draw.get_height = love.graphics.getHeight
+Draw.get_height = draw.get_height
 
 --- @function Draw.create_canvas
 Draw.create_canvas = love.graphics.newCanvas

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -44,6 +44,12 @@ Draw.get_width = draw.get_width
 --- @function Draw.get_height
 Draw.get_height = draw.get_height
 
+--- @function Draw.get_actual_width
+Draw.get_actual_width = draw.get_actual_width
+
+--- @function Draw.get_actual_height
+Draw.get_actual_height = draw.get_actual_height
+
 --- @function Draw.create_canvas
 Draw.create_canvas = love.graphics.newCanvas
 

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -38,6 +38,18 @@ Draw.set_font = draw.set_font
 Draw.run = draw.run
 
 
+Draw.set_canvas_background_color = draw.set_canvas_background_color
+
+Draw.get_canvas_background_color = draw.get_canvas_background_color
+
+
+Draw.get_logical_viewport = draw.get_logical_viewport
+
+Draw.set_logical_viewport = draw.set_logical_viewport
+
+Draw.set_logical_viewport_enabled = draw.set_logical_viewport_enabled
+
+
 --- @function Draw.get_width
 Draw.get_width = draw.get_width
 
@@ -55,6 +67,7 @@ Draw.create_canvas = love.graphics.newCanvas
 
 Draw.copy_to_canvas = draw.copy_to_canvas
 
+
 Draw.add_global_draw_callback = draw.add_global_draw_callback
 
 Draw.remove_global_draw_callback = draw.remove_global_draw_callback
@@ -62,6 +75,14 @@ Draw.remove_global_draw_callback = draw.remove_global_draw_callback
 Draw.wait_global_draw_callbacks = draw.wait_global_draw_callbacks
 
 Draw.has_active_global_draw_callbacks = draw.has_active_global_draw_callbacks
+
+
+Draw.register_global_layer = draw.register_global_layer
+
+Draw.unregister_global_layer = draw.unregister_global_layer
+
+Draw.set_global_layer_enabled = draw.set_global_layer_enabled
+
 
 --- Sets the current drawing color. You can provide a table of up to  four
 --- values or four separate integers.

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -451,7 +451,7 @@ function Draw.set_line_width(width)
 end
 
 function Draw.set_default_filter(min, mag, anisotropy)
-   love.graphics.setDefaultFilter(min or "nearest", mag or "nearest", anisotropy or 1)
+   love.graphics.setDefaultFilter(min or "linear", mag or "linear", anisotropy or 1)
 end
 
 function Draw.set_scissor(x, y, width, height)

--- a/src/api/Draw.lua
+++ b/src/api/Draw.lua
@@ -45,6 +45,8 @@ Draw.get_canvas_background_color = draw.get_canvas_background_color
 
 Draw.get_logical_viewport = draw.get_logical_viewport
 
+Draw.get_logical_viewport_bounds = draw.get_logical_viewport_bounds
+
 Draw.set_logical_viewport = draw.set_logical_viewport
 
 Draw.set_logical_viewport_enabled = draw.set_logical_viewport_enabled
@@ -82,6 +84,8 @@ Draw.register_global_layer = draw.register_global_layer
 Draw.unregister_global_layer = draw.unregister_global_layer
 
 Draw.set_global_layer_enabled = draw.set_global_layer_enabled
+
+Draw.get_global_layer = draw.get_global_layer
 
 
 --- Sets the current drawing color. You can provide a table of up to  four

--- a/src/api/Gui.lua
+++ b/src/api/Gui.lua
@@ -520,6 +520,7 @@ end
 --- @tparam[opt] int y
 --- @tparam[opt] number volume
 --- @tparam[opt] int channel
+--- @treturn number sound duration
 function Gui.play_sound(sound_id, x, y, volume, channel)
    if not config.base.sound then
       return
@@ -534,6 +535,36 @@ function Gui.play_sound(sound_id, x, y, volume, channel)
    else
       sound_manager:play(sound_id, nil, nil, volume, channel)
    end
+end
+
+function Gui.stop_sound_on(channel)
+   if not config.base.sound then
+      return
+   end
+
+   local sound_manager = require("internal.global.global_sound_manager")
+
+   return sound_manager:stop(channel)
+end
+
+function Gui.get_sound_duration(channel, unit)
+   if not config.base.sound then
+      return -1
+   end
+
+   local sound_manager = require("internal.global.global_sound_manager")
+
+   return sound_manager:get_sound_duration(channel, unit)
+end
+
+function Gui.is_sound_playing_on(channel)
+   if not config.base.sound then
+      return false
+   end
+
+   local sound_manager = require("internal.global.global_sound_manager")
+
+   return sound_manager:is_playing(channel)
 end
 
 --- Plays a sound looped in the background.

--- a/src/api/Gui.lua
+++ b/src/api/Gui.lua
@@ -17,6 +17,7 @@ local InstancedMap = require("api.InstancedMap")
 local MapObject = require("api.MapObject")
 local Event = require("api.Event")
 local DrawLayerSpec = require("api.draw.DrawLayerSpec")
+local main_state = require("internal.global.main_state")
 
 local Gui = {}
 
@@ -604,8 +605,14 @@ function Gui.bind_keys(keys)
    field:bind_keys(keys)
 end
 
-function Gui.field_is_active()
-   return field.is_active
+function Gui.get_active_state()
+   if field.is_active then
+      return "field"
+   elseif main_state.is_main_title_reached then
+      return "main_title"
+   else
+      return "initializing"
+   end
 end
 
 function Gui.add_hud_widget(widget, tag, opts)

--- a/src/api/Input.lua
+++ b/src/api/Input.lua
@@ -245,8 +245,14 @@ function Input.clear_macro_queue()
    draw.get_current_layer().layer:clear_macro_queue()
 end
 
-function Input.mouse_pos()
+function Input.actual_mouse_pos()
    return love.mouse.getPosition()
+end
+
+function Input.mouse_pos()
+   local x, y = Input.actual_mouse_pos()
+   local lx, ly = draw.get_logical_viewport()
+   return x - lx, y - ly
 end
 
 return Input

--- a/src/api/Ui.lua
+++ b/src/api/Ui.lua
@@ -21,7 +21,7 @@ local tile_size = 48
 --- @tparam[opt] boolean tiled
 function Ui.params_centered(width, height, tiled)
    if tiled == nil then
-      tiled = Gui.field_is_active()
+      tiled = Gui.get_active_state() == "field"
    end
 
    local x = (Draw.get_width() - width) / 2

--- a/src/api/gui/ILayer.lua
+++ b/src/api/gui/ILayer.lua
@@ -1,0 +1,16 @@
+local IDrawable = require("api.gui.IDrawable")
+local ILayer = class.interface("ILayer", { relayout = "function" }, { IDrawable })
+
+ILayer.DEFAULT_Z_ORDER = 100000
+
+function ILayer:default_z_order()
+   return nil
+end
+
+function ILayer:release()
+end
+
+function ILayer:on_hotload_layer()
+end
+
+return ILayer

--- a/src/api/gui/IUiLayer.lua
+++ b/src/api/gui/IUiLayer.lua
@@ -1,22 +1,17 @@
 local Env = require("api.Env")
 local Log = require("api.Log")
-local IDrawable = require("api.gui.IDrawable")
 local IInput = require("api.gui.IInput")
 local config = require("internal.config")
 local IHud = require("api.gui.hud.IHud")
+local ILayer = require("api.gui.ILayer")
 
 local draw = require("internal.draw")
 
 local IUiLayer = class.interface("IUiLayer",
                                  {
-                                    relayout = "function",
                                     make_keymap = "function",
                                  },
-                                 { IDrawable, IInput })
-
-function IUiLayer:default_z_order()
-   return nil
-end
+                                 { ILayer, IInput })
 
 local function trimmed_traceback(err, regex)
    local lines = {}
@@ -155,13 +150,7 @@ function IUiLayer:is_querying()
    return self == current
 end
 
-function IUiLayer:release()
-end
-
 function IUiLayer:on_query()
-end
-
-function IUiLayer:on_hotload_layer()
 end
 
 return IUiLayer

--- a/src/api/gui/PagedListModel.lua
+++ b/src/api/gui/PagedListModel.lua
@@ -57,7 +57,7 @@ function PagedListModel:selected_index()
 end
 
 function PagedListModel:update_selected_index()
-   self.selected_ = self.page_size * self.page + self.model:selected_index()
+   self.selected_ = math.clamp(self.page_size * self.page + self.model:selected_index(), 1, self:len())
 end
 
 function PagedListModel:select(i)

--- a/src/api/gui/Pcc.lua
+++ b/src/api/gui/Pcc.lua
@@ -78,6 +78,7 @@ function Pcc:refresh()
       self.image:release()
    end
    self.image = love.graphics.newImage(canvas:newImageData())
+   self.image:setFilter("nearest", "nearest", 1)
 
    canvas:release()
 

--- a/src/api/gui/PlayerLightDrawable.lua
+++ b/src/api/gui/PlayerLightDrawable.lua
@@ -15,7 +15,6 @@ function PlayerLightDrawable:init()
    self.offset_x = math.floor(tw / 2)
    self.offset_y = math.floor(th / 2)
    self.t = nil
-   self.dirty = true
 end
 
 function PlayerLightDrawable:is_drawable_in_ui()
@@ -27,7 +26,6 @@ function PlayerLightDrawable:serialize()
 end
 
 function PlayerLightDrawable:deserialize()
-   self.dirty = true
 end
 
 function PlayerLightDrawable:update(dt)
@@ -48,7 +46,7 @@ function PlayerLightDrawable:update(dt)
 end
 
 function PlayerLightDrawable:draw(x, y, w, h, centered, rot)
-   if self.dirty then
+   if self.t == nil then
       self.t = UiTheme.load(self)
    end
    Draw.set_blend_mode("add")

--- a/src/api/gui/WidgetContainer.lua
+++ b/src/api/gui/WidgetContainer.lua
@@ -67,7 +67,7 @@ function WidgetContainer:relayout(x, y, width, height)
       local position = holder:position() or widget.default_widget_position
       local _x, _y, _width, _height = position(widget, x, y, width, height)
 
-      holder:widget():relayout(_x, _y, _width, _height)
+      holder:widget():relayout(_x or x, _y or y, _width or width, _height or height)
    end
 end
 

--- a/src/api/gui/hud/UiFpsCounter.lua
+++ b/src/api/gui/hud/UiFpsCounter.lua
@@ -28,7 +28,7 @@ function UiFpsCounter:default_widget_position(x, y, width, height)
 end
 
 function UiFpsCounter:relayout(x, y, width, height)
-   self.x = Draw.get_width() - Draw.text_width(self.buff) - 20
+   self.x = width - Draw.text_width(self.buff) - 20
    self.y = y or self.y
 end
 
@@ -91,7 +91,7 @@ function UiFpsCounter:update()
       local x = self.x - 105
 
       if relayout then
-         self:relayout()
+         self:relayout(self.x, self.y, self.width, self.height)
       end
       self.fps_graph:relayout(x, 5, 100, 40)
       self.ram_graph:relayout(x, 5 + 45, 100, 40)

--- a/src/api/gui/menu/WindowTitle.lua
+++ b/src/api/gui/menu/WindowTitle.lua
@@ -34,7 +34,7 @@ function WindowTitle:draw()
    end
 
    local offset_y = 0
-   if Gui.field_is_active() then
+   if Gui.get_active_state() == "field" then
       offset_y = 1
    end
    self.t.base.tip_icons:draw_region(1, self.x, self.y + offset_y)

--- a/src/game/field_layer.lua
+++ b/src/game/field_layer.lua
@@ -82,6 +82,14 @@ function field_layer:init_global_data()
    Event.trigger("base.on_init_save")
 end
 
+function field_layer:get_renderer_y_offset()
+   local y_offset = -(72 + 16)
+   if self.view_centered then
+      y_offset = 0
+   end
+   return y_offset
+end
+
 function field_layer:set_map(map)
    assert(type(map) == "table")
    assert(map.uid, "Map must have UID")
@@ -93,7 +101,9 @@ function field_layer:set_map(map)
    else
       self.renderer:set_map_size(map:width(), map:height(), self.draw_layer_spec)
    end
-   self.renderer:relayout(self.x, self.y, self.width, self.height)
+   if self.x then
+      self:relayout()
+   end
 
    self.map_changed = true
    self.no_scroll = true
@@ -105,11 +115,7 @@ function field_layer:relayout(x, y, width, height)
    self.width = width or self.width
    self.height = height or self.height
    if self.renderer then
-      local offset_y = -(72 + 16)
-      if self.view_centered then
-         offset_y = 0
-      end
-      self.renderer:relayout(self.x, self.y, self.width, self.height + offset_y)
+      self.renderer:relayout(self.x, self.y, self.width, self.height + self:get_renderer_y_offset())
    end
 end
 

--- a/src/internal/draw.lua
+++ b/src/internal/draw.lua
@@ -86,7 +86,7 @@ function draw.get_actual_height()
 end
 
 function draw.get_logical_viewport()
-   return 0, 0, draw.get_width(), draw.get_height()
+   return lx, ly, lw, lh
 end
 
 function draw.set_logical_viewport(x, y, w, h)
@@ -200,7 +200,7 @@ function draw.set_root(ui_layer, priority)
    class.assert_is_an(require("api.gui.IUiLayer"), ui_layer)
    layers = {{layer=ui_layer, priority=priority}}
    sort_layers()
-   ui_layer:relayout(draw.get_logical_viewport())
+   ui_layer:relayout(0, 0, draw.get_width(), draw.get_height())
    ui_layer:focus()
 end
 
@@ -214,7 +214,7 @@ end
 function draw.push_layer(ui_layer, priority)
    class.assert_is_an(require("api.gui.IUiLayer"), ui_layer)
    priority = priority or ui_layer:default_z_order()
-   ui_layer:relayout(draw.get_logical_viewport())
+   ui_layer:relayout(0, 0, draw.get_width(), draw.get_height())
    ui_layer:focus()
    table.insert(layers, {layer=ui_layer, priority=priority})
    sort_layers()
@@ -275,7 +275,7 @@ local function hotload_layer(layer)
    if layer.on_hotload_layer then
       layer:on_hotload_layer()
    end
-   layer:relayout(draw.get_logical_viewport())
+   layer:relayout(0, 0, draw.get_width(), draw.get_height())
 
    layer:bind_keys(layer:make_keymap())
 end

--- a/src/internal/draw.lua
+++ b/src/internal/draw.lua
@@ -117,7 +117,7 @@ function draw.init()
    set_window_mode(WIDTH, HEIGHT)
 
    love.graphics.setLineStyle("rough")
-   love.graphics.setDefaultFilter("nearest", "nearest", 1)
+   love.graphics.setDefaultFilter("linear", "linear", 1)
    love.graphics.setBlendMode("alpha")
 
    gamma_correct = love.graphics.newShader("mod/base/graphic/shader/gamma.frag.glsl")
@@ -527,8 +527,12 @@ function draw.set_font(size, style, filename)
    style = style or "normal"
    filename = filename or default_font
    if not font_cache[size] then font_cache[size] = setmetatable({}, { __mode = "v" }) end
-   font_cache[size][filename] = font_cache[size][filename]
-      or love.graphics.newFont(filename, size, "mono")
+   if not font_cache[size][filename] then
+      local font = love.graphics.newFont(filename, size, "mono")
+      font:setFilter("nearest", "nearest", 1)
+      font_cache[size][filename] = font
+   end
+
    love.graphics.setFont(font_cache[size][filename])
 end
 

--- a/src/internal/draw.lua
+++ b/src/internal/draw.lua
@@ -85,6 +85,10 @@ function draw.get_actual_height()
    return love.graphics.getHeight()
 end
 
+function draw.get_logical_viewport_bounds()
+   return lx, ly, draw.get_width(), draw.get_height()
+end
+
 function draw.get_logical_viewport()
    return lx, ly, lw, lh
 end
@@ -344,7 +348,9 @@ function draw.set_global_layer_enabled(tag, enabled)
 end
 
 function draw.get_global_layer(tag)
-   assert(global_layers[tag], "No layer with tag " .. tostring(tag) .. " found")
+   if global_layers[tag] == nil then
+      return nil
+   end
    return global_layers[tag].layer
 end
 

--- a/src/internal/draw.lua
+++ b/src/internal/draw.lua
@@ -345,6 +345,7 @@ end
 function draw.set_global_layer_enabled(tag, enabled)
    assert(global_layers[tag], "No layer with tag " .. tostring(tag) .. " found")
    global_layers[tag].enabled = not not enabled
+   sort_global_layers()
 end
 
 function draw.get_global_layer(tag)

--- a/src/internal/draw/asset_drawable.lua
+++ b/src/internal/draw/asset_drawable.lua
@@ -38,15 +38,24 @@ local function crop(proto)
 end
 
 local function load_image_region(proto)
+   local image
    if proto.image then
-      return bmp_convert.load_image(proto.image, proto.key_color)
+      image = bmp_convert.load_image(proto.image, proto.key_color)
    end
 
    if proto.source then
-      return crop(proto)
+      image = crop(proto)
    end
 
-   error(("invalid image asset (%s): must contain {image} or {source,x,y,width,height}"):format(proto._id))
+   if image == nil then
+      error(("invalid image asset (%s): must contain {image} or {source,x,y,width,height}"):format(proto._id))
+   end
+
+   if proto.filter then
+      image:setFilter(proto.filter.min, proto.filter.mag, proto.filter.anisotropy)
+   end
+
+   return image
 end
 
 function asset_drawable:init(proto)

--- a/src/internal/draw/atlas.lua
+++ b/src/internal/draw/atlas.lua
@@ -4,6 +4,7 @@ local asset_drawable = require("internal.draw.asset_drawable")
 local atlas_batch = require("internal.draw.atlas_batch")
 local binpack = require("thirdparty.binpack")
 local bmp_convert = require("internal.bmp_convert")
+local Draw = require("api.Draw")
 
 local atlas = class.class("atlas")
 
@@ -52,7 +53,7 @@ local function load_tile(spec, frame_id, offset_x, offset_y)
    return tile, quad
 end
 
-function atlas:init(tile_width, tile_height)
+function atlas:init(tile_width, tile_height, opts)
    self.tile_width = tile_width
    self.tile_height = tile_height
    self.tiles = {}
@@ -64,6 +65,11 @@ function atlas:init(tile_width, tile_height)
    self.anims = {}
    self.existing = {}
    self.rects = {}
+
+   self.filter = (opts and opts.filter) or {}
+   self.filter.min = self.filter.min or "nearest"
+   self.filter.mag = self.filter.mag or "nearest"
+   self.filter.anisotropy = self.filter.anisotropy or 1
 
    -- blank fallback in case of missing filepath.
    local fallback_data = love.image.newImageData(self.tile_width, self.tile_height)
@@ -267,9 +273,11 @@ function atlas:load(protos, coords, cb)
 
    cb = cb or function(self, proto) self:load_one(proto) end
 
+   Draw.set_default_filter(self.filter.min, self.filter.mag, self.filter.anisotropy)
    for _, proto in ipairs(protos) do
       cb(self, proto)
    end
+   Draw.set_default_filter()
 
    Log.debug("%d/%d tiles filled.", count, self.tile_count_x * self.tile_count_y)
 

--- a/src/internal/draw/atlas.lua
+++ b/src/internal/draw/atlas.lua
@@ -270,14 +270,14 @@ function atlas:load(protos, coords, cb)
    love.graphics.setCanvas(canvas)
    love.graphics.setBlendMode("alpha")
    love.graphics.setColor(1, 1, 1, 1)
+   Draw.set_default_filter(self.filter.min, self.filter.mag, self.filter.anisotropy)
 
    cb = cb or function(self, proto) self:load_one(proto) end
 
-   Draw.set_default_filter(self.filter.min, self.filter.mag, self.filter.anisotropy)
+
    for _, proto in ipairs(protos) do
       cb(self, proto)
    end
-   Draw.set_default_filter()
 
    Log.debug("%d/%d tiles filled.", count, self.tile_count_x * self.tile_count_y)
 
@@ -287,6 +287,8 @@ function atlas:load(protos, coords, cb)
    canvas:release()
 
    self.batch = love.graphics.newSpriteBatch(self.image)
+
+   Draw.set_default_filter()
 end
 
 function atlas:make_anim(tile_id)

--- a/src/internal/draw/coords/iso_coords.lua
+++ b/src/internal/draw/coords/iso_coords.lua
@@ -1,5 +1,6 @@
 local ICoords = require("internal.draw.coords.ICoords")
 local iso_coords = class.class("iso_coords", ICoords)
+local Draw = require("api.Draw")
 
 function iso_coords:get_size()
    return 64, 64
@@ -22,8 +23,8 @@ end
 function iso_coords:find_bounds(x, y, width, height)
    local tile_width = 64
    local tile_height = 64
-   local draw_width = love.graphics.getWidth()*2
-   local draw_height = love.graphics.getHeight()*2
+   local draw_width = Draw.get_width()*2
+   local draw_height = Draw.get_height()*2
    local tx = math.floor(x / tile_width) - 1
    local ty = math.floor(y / tile_height) - 1
    local tdx = math.min(math.ceil((x + draw_width) / tile_width), width*2)

--- a/src/internal/draw/tile_batch.lua
+++ b/src/internal/draw/tile_batch.lua
@@ -30,8 +30,8 @@ function tile_batch:on_theme_switched(atlas, coords)
 end
 
 function tile_batch:find_bounds(x, y)
-   local draw_width = love.graphics.getWidth()
-   local draw_height = love.graphics.getHeight()
+   local draw_width = Draw.get_width()
+   local draw_height = Draw.get_height()
    local tx = math.floor(x / self.tile_width) - 1
    local ty = math.floor(y / self.tile_height) - 1
    local tdx = math.min(math.ceil((x + draw_width) / self.tile_width), self.width)

--- a/src/internal/events/widget.lua
+++ b/src/internal/events/widget.lua
@@ -41,4 +41,4 @@ local function add_default_widgets()
    end
    Gui.add_hud_widget(UiBar:new("hud_mp_bar", 0, 0, true), "hud_mp_bar", { position = position, refresh = refresh })
 end
-Event.register("base.before_engine_init", "Add default_widgets", add_default_widgets, {priority = 10000})
+Event.register("base.before_engine_init", "Add default widgets", add_default_widgets, {priority = 10000})

--- a/src/internal/input.lua
+++ b/src/internal/input.lua
@@ -1,6 +1,7 @@
 local IMouseInput = require("api.gui.IMouseInput")
 local IKeyInput = require("api.gui.IKeyInput")
 local config = require("internal.config")
+local draw = require("internal.draw")
 
 local input = {}
 
@@ -16,19 +17,22 @@ end
 
 function input.mousemoved(x, y, dx, dy, istouch)
    if mouse_handler then
-      mouse_handler:receive_mouse_movement(x, y, dx, dy)
+      local lx, ly = draw.get_logical_viewport()
+      mouse_handler:receive_mouse_movement(x - lx, y - ly, dx, dy)
    end
 end
 
 function input.mousepressed(x, y, button, istouch)
    if mouse_handler then
-      mouse_handler:receive_mouse_button(x, y, button, true)
+      local lx, ly = draw.get_logical_viewport()
+      mouse_handler:receive_mouse_button(x - lx, y - ly, button, true)
    end
 end
 
 function input.mousereleased(x, y, button, istouch)
    if mouse_handler then
-      mouse_handler:receive_mouse_button(x, y, button, false)
+      local lx, ly = draw.get_logical_viewport()
+      mouse_handler:receive_mouse_button(x - lx, y - ly, button, false)
    end
 end
 

--- a/src/internal/layer/global/canvas_layer.lua
+++ b/src/internal/layer/global/canvas_layer.lua
@@ -1,0 +1,23 @@
+local ILayer = require("api.gui.ILayer")
+local draw = require("internal.draw")
+
+local canvas_layer = class.class("canvas_layer", ILayer)
+
+function canvas_layer:init()
+end
+
+function canvas_layer:default_z_order()
+   return 100000
+end
+
+function canvas_layer:relayout()
+end
+
+function canvas_layer:draw()
+   draw.draw_inner_canvas()
+end
+
+function canvas_layer:update()
+end
+
+return canvas_layer

--- a/src/internal/layer/global/canvas_layer.lua
+++ b/src/internal/layer/global/canvas_layer.lua
@@ -1,5 +1,6 @@
 local ILayer = require("api.gui.ILayer")
 local draw = require("internal.draw")
+local Draw = require("api.Draw")
 
 local canvas_layer = class.class("canvas_layer", ILayer)
 
@@ -14,10 +15,11 @@ function canvas_layer:relayout()
 end
 
 function canvas_layer:draw()
+   Draw.set_color(255, 255, 255, 255)
    draw.draw_inner_canvas()
 end
 
-function canvas_layer:update()
+function canvas_layer:update(dt)
 end
 
 return canvas_layer

--- a/src/internal/sound_manager.lua
+++ b/src/internal/sound_manager.lua
@@ -171,7 +171,7 @@ function sound_manager:play(id, x, y, volume, channel)
    local channel = channel or src
 
    if self.sources[channel] then
-      love.audio.stop()
+      love.audio.stop(src)
    end
 
    self.sources[channel] = src

--- a/src/internal/sound_manager.lua
+++ b/src/internal/sound_manager.lua
@@ -20,9 +20,9 @@ end
 
 function sound_manager:update()
    local remove = {}
-   for _, s in pairs(self.sources) do
+   for channel, s in pairs(self.sources) do
       if not s:isPlaying() then
-         remove[#remove + 1] = s
+         remove[#remove + 1] = channel
       end
    end
 
@@ -175,6 +175,22 @@ function sound_manager:play(id, x, y, volume, channel)
    end
 
    self.sources[channel] = src
+end
+
+function sound_manager:is_playing(channel)
+   local src = self.sources[channel]
+   if src == nil then
+      return false
+   end
+
+   return src:isPlaying()
+end
+
+function sound_manager:get_sound_duration(channel, unit)
+   local src = self.sources[channel]
+   if src == nil then return -1 end
+
+   return src:getDuration(unit)
 end
 
 function sound_manager:stop(channel)

--- a/src/internal/theme.lua
+++ b/src/internal/theme.lua
@@ -230,7 +230,7 @@ function theme.reload_all(log_cb)
       -- method, using "self.t = UiTheme.load()" or similar. Maybe this isn't a
       -- good way of standardizing things for modders, seeing as this is not
       -- handled automatically, but for now it works, so I won't complain...
-      draw.resize(nil, nil)
+      draw.resize(draw.get_actual_width(), draw.get_actual_height())
 
       -- Update each draw layer with the new tile/chip atlases.
       field:on_theme_switched()

--- a/src/main.lua
+++ b/src/main.lua
@@ -173,7 +173,6 @@ function love.draw()
       start_halt()
       halt_error = tostring(err)
    end
-   draw.draw_global_draw_callbacks()
 
    draw.draw_end()
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -105,15 +105,26 @@ function love.update(dt)
       return
    end
 
-   draw.update_global_layers(dt)
-
-   local ok, err = xpcall(draw.update_global_widgets, debug.traceback, dt)
+   local ok, err = xpcall(draw.update_global_layers, debug.traceback, dt)
    if not ok then
-      halt_error = err
-      print("Error in global widgets:\n\t" .. debug.traceback(loop_coro, halt_error))
+      halt_error = tostring(err)
+      print("Error in global layers (update):\n\t" .. debug.traceback(loop_coro, halt_error))
       start_halt()
    end
-   draw.update_global_draw_callbacks(dt)
+
+   ok, err = xpcall(draw.update_global_draw_callbacks, debug.traceback, dt)
+   if not ok then
+      halt_error = err
+      print("Error in global draw callbacks (update):\n\t" .. debug.traceback(loop_coro, halt_error))
+      start_halt()
+   end
+
+   ok, err = xpcall(draw.update_global_widgets, debug.traceback, dt)
+   if not ok then
+      halt_error = err
+      print("Error in global widgets (update):\n\t" .. debug.traceback(loop_coro, halt_error))
+      start_halt()
+   end
 
    ok, err = coroutine.resume(loop_coro, dt, pop_draw_layer)
    pop_draw_layer = false
@@ -181,13 +192,24 @@ function love.draw()
    do
       draw.draw_outer_start()
 
-      draw.draw_global_layers()
-
-      draw.draw_global_draw_callbacks()
-      local ok, err = xpcall(draw.draw_global_widgets, debug.traceback)
+      local ok, err = xpcall(draw.draw_global_layers, debug.traceback)
       if not ok then
          halt_error = tostring(err)
-         print("Error in global widgets:\n\t" .. debug.traceback(loop_coro, halt_error))
+         print("Error in global layers (draw):\n\t" .. debug.traceback(loop_coro, halt_error))
+         start_halt()
+      end
+
+      ok, err = xpcall(draw.draw_global_draw_callbacks, debug.traceback)
+      if not ok then
+         halt_error = tostring(err)
+         print("Error in global draw callbacks (draw):\n\t" .. debug.traceback(loop_coro, halt_error))
+         start_halt()
+      end
+
+      ok, err = xpcall(draw.draw_global_widgets, debug.traceback)
+      if not ok then
+         halt_error = tostring(err)
+         print("Error in global widgets (draw):\n\t" .. debug.traceback(loop_coro, halt_error))
          start_halt()
       end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -8,6 +8,7 @@ local debug_server = require("internal.debug_server")
 local input = require("internal.input")
 local draw = require("internal.draw")
 local main_state = require("internal.global.main_state")
+local canvas_layer = require("internal.layer.global.canvas_layer")
 
 local loop_coro = nil
 local draw_coro = nil
@@ -29,6 +30,8 @@ function love.load(arg)
 
    loop_coro = coroutine.create(game.loop)
    draw_coro = coroutine.create(game.draw)
+
+   draw.register_global_layer("canvas", canvas_layer:new())
 end
 
 local halt = false

--- a/src/mod/damage_popups/api/gui/DamagePopupLayer.lua
+++ b/src/mod/damage_popups/api/gui/DamagePopupLayer.lua
@@ -1,8 +1,7 @@
 local Draw = require("api.Draw")
 local IDrawLayer = require("api.gui.IDrawLayer")
 local Gui = require("api.Gui")
-
-local easing = require("mod.damage_popups.lib.easing")
+local Easing = require("mod.extlibs.api.Easing")
 
 local DamagePopupLayer = class.class("DamagePopupLayer", IDrawLayer)
 
@@ -39,7 +38,7 @@ function DamagePopupLayer:update(map, dt, screen_updated)
 
    for i, v in ipairs(popups) do
       v.frame = v.frame + dt * 50
-      local alpha = math.min(easing.outQuint(1 - (v.frame / max_frame), 0, 1, 1) * 255, 255)
+      local alpha = math.min(Easing.outQuint(1 - (v.frame / max_frame), 0, 1, 1) * 255, 255)
       v.color[4] = alpha
       v.shadow_color[4] = alpha
       if v.frame > max_frame then

--- a/src/mod/damage_popups/mod.lua
+++ b/src/mod/damage_popups/mod.lua
@@ -2,6 +2,7 @@ return {
    id = "damage_popups",
    version = "0.1.0",
    dependencies = {
-      elona = ">= 0"
+      elona = ">= 0",
+      extlibs = ">= 0",
    }
 }

--- a/src/mod/elona/api/Effect.lua
+++ b/src/mod/elona/api/Effect.lua
@@ -1132,7 +1132,7 @@ function Effect.love_miracle(chara)
          item.value = math.clamp(math.floor(weight * weight / 10000), 200, 40000)
       end
    else
-      local item = Item.create("elona.bottle_of_milk", chara.x, chara.y, params, chara:current_map())
+      Item.create("elona.bottle_of_milk", chara.x, chara.y, params, chara:current_map())
    end
 
    Gui.play_sound("base.atk_elec")

--- a/src/mod/elona/api/gui/MapEditLayer.lua
+++ b/src/mod/elona/api/gui/MapEditLayer.lua
@@ -126,7 +126,7 @@ function MapEditLayer:show_tiles()
 end
 
 function MapEditLayer:on_query()
-   assert(Gui.field_is_active(), "Can only start in-game")
+   assert(Gui.get_active_state() == "field", "Can only start in-game")
    assert(not Map.is_world_map(), "Can't start in world map")
 end
 

--- a/src/mod/elona/data/inventory_proto.lua
+++ b/src/mod/elona/data/inventory_proto.lua
@@ -231,6 +231,7 @@ local inv_eat = {
          return "player_turn_query"
       end
 
+      ctxt:set_menu_visible(false)
       return ElonaAction.eat(ctxt.chara, item)
       -- <<<<<<<< shade2/command.hsp:3736 			goto *act_eat ..
    end
@@ -281,6 +282,7 @@ local inv_read = {
       return item:calc("can_read")
    end,
    on_select = function(ctxt, item)
+      ctxt:set_menu_visible(false)
       return ElonaAction.read(ctxt.chara, item)
    end
 }

--- a/src/mod/elona/data/inventory_proto.lua
+++ b/src/mod/elona/data/inventory_proto.lua
@@ -1079,7 +1079,7 @@ local inv_harvest_delivery_chest = {
       assert(quest._id == "elona.harvest", quest._id)
       quest.params.current_weight = quest.params.current_weight + item:calc("weight") * item.amount
       Gui.mes_c("ui.inv.put.harvest", "Green",
-                item,
+                item:build_name(amount),
                 Ui.display_weight(item:calc("weight") * item.amount),
                 Ui.display_weight(quest.params.current_weight),
                 Ui.display_weight(quest.params.required_weight))
@@ -1136,6 +1136,9 @@ local inv_mages_guild_delivery_chest = {
       local aspect = assert(item:get_aspect(IItemAncientBook))
       local points_earned = (aspect:calc(item, "difficulty") + 1) * amount
       save.elona.guild_mage_point_quota = math.max(save.elona.guild_mage_point_quota - points_earned, 0)
+      local mes = I18N.get("ui.inv.put.guild.you_deliver", item:build_name(amount))
+      mes = ("%s(%d Guild Point)"):format(mes, points_earned)
+      Gui.mes_c(mes, "Green")
       if save.elona.guild_mage_point_quota == 0 then
          Gui.play_sound("base.complete1")
          Gui.mes_c("ui.inv.put.guild.you_fulfill", "Green")

--- a/src/mod/elona/data/item/furniture.lua
+++ b/src/mod/elona/data/item/furniture.lua
@@ -3911,6 +3911,7 @@ data:add {
    skill = "elona.performer",
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    params = { instrument_quality = 110 },
 
@@ -3937,6 +3938,7 @@ data:add {
    skill = "elona.performer",
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    params = { instrument_quality = 150 },
 
@@ -3963,6 +3965,7 @@ data:add {
    skill = "elona.performer",
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    params = { instrument_quality = 130 },
 
@@ -3988,6 +3991,7 @@ data:add {
    skill = "elona.performer",
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    params = { instrument_quality = 70 },
 
@@ -4014,6 +4018,7 @@ data:add {
    skill = "elona.performer",
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    params = { instrument_quality = 175 },
 
@@ -4038,6 +4043,7 @@ data:add {
 
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    is_precious = true,
    params = { instrument_quality = 180 },
@@ -4072,6 +4078,7 @@ data:add {
 
    on_use = function(self, params)
       Magic.cast("elona.performer", { source = params.chara, item = self })
+      return "turn_end"
    end,
    is_precious = true,
    params = { instrument_quality = 200 },

--- a/src/mod/elona/data/item/potion.lua
+++ b/src/mod/elona/data/item/potion.lua
@@ -7,6 +7,7 @@ local Effect = require("mod.elona.api.Effect")
 local Skill = require("mod.elona_sys.api.Skill")
 local light = require("mod.elona.data.item.light")
 local IItemPotion = require("mod.elona.api.aspect.IItemPotion")
+local IItemFromChara = require("mod.elona.api.aspect.IItemFromChara")
 
 --
 -- Potion
@@ -752,7 +753,8 @@ data:add {
          effects = {
             {_id = "elona.milk", power = 100}
          }
-      }
+      },
+      IItemFromChara
    }
 }
 

--- a/src/mod/extlibs/api/Easing.lua
+++ b/src/mod/extlibs/api/Easing.lua
@@ -37,23 +37,23 @@ local sqrt = math.sqrt
 local abs = math.abs
 local asin  = math.asin
 
-local easing = {}
+local Easing = {}
 
-function easing.linear(t, b, c, d)
+function Easing.linear(t, b, c, d)
   return c * t / d + b
 end
 
-function easing.inQuad(t, b, c, d)
+function Easing.inQuad(t, b, c, d)
   t = t / d
   return c * pow(t, 2) + b
 end
 
-function easing.outQuad(t, b, c, d)
+function Easing.outQuad(t, b, c, d)
   t = t / d
   return -c * t * (t - 2) + b
 end
 
-function easing.inOutQuad(t, b, c, d)
+function Easing.inOutQuad(t, b, c, d)
   t = t / d * 2
   if t < 1 then
     return c / 2 * pow(t, 2) + b
@@ -62,25 +62,25 @@ function easing.inOutQuad(t, b, c, d)
   end
 end
 
-function easing.outInQuad(t, b, c, d)
+function Easing.outInQuad(t, b, c, d)
   if t < d / 2 then
-    return easing.outQuad (t * 2, b, c / 2, d)
+    return Easing.outQuad (t * 2, b, c / 2, d)
   else
-    return easing.inQuad((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inQuad((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inCubic (t, b, c, d)
+function Easing.inCubic (t, b, c, d)
   t = t / d
   return c * pow(t, 3) + b
 end
 
-function easing.outCubic(t, b, c, d)
+function Easing.outCubic(t, b, c, d)
   t = t / d - 1
   return c * (pow(t, 3) + 1) + b
 end
 
-function easing.inOutCubic(t, b, c, d)
+function Easing.inOutCubic(t, b, c, d)
   t = t / d * 2
   if t < 1 then
     return c / 2 * t * t * t + b
@@ -90,25 +90,25 @@ function easing.inOutCubic(t, b, c, d)
   end
 end
 
-function easing.outInCubic(t, b, c, d)
+function Easing.outInCubic(t, b, c, d)
   if t < d / 2 then
-    return easing.outCubic(t * 2, b, c / 2, d)
+    return Easing.outCubic(t * 2, b, c / 2, d)
   else
-    return easing.inCubic((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inCubic((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inQuart(t, b, c, d)
+function Easing.inQuart(t, b, c, d)
   t = t / d
   return c * pow(t, 4) + b
 end
 
-function easing.outQuart(t, b, c, d)
+function Easing.outQuart(t, b, c, d)
   t = t / d - 1
   return -c * (pow(t, 4) - 1) + b
 end
 
-function easing.inOutQuart(t, b, c, d)
+function Easing.inOutQuart(t, b, c, d)
   t = t / d * 2
   if t < 1 then
     return c / 2 * pow(t, 4) + b
@@ -118,25 +118,25 @@ function easing.inOutQuart(t, b, c, d)
   end
 end
 
-function easing.outInQuart(t, b, c, d)
+function Easing.outInQuart(t, b, c, d)
   if t < d / 2 then
-    return easing.outQuart(t * 2, b, c / 2, d)
+    return Easing.outQuart(t * 2, b, c / 2, d)
   else
-    return easing.inQuart((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inQuart((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inQuint(t, b, c, d)
+function Easing.inQuint(t, b, c, d)
   t = t / d
   return c * pow(t, 5) + b
 end
 
-function easing.outQuint(t, b, c, d)
+function Easing.outQuint(t, b, c, d)
   t = t / d - 1
   return c * (pow(t, 5) + 1) + b
 end
 
-function easing.inOutQuint(t, b, c, d)
+function Easing.inOutQuint(t, b, c, d)
   t = t / d * 2
   if t < 1 then
     return c / 2 * pow(t, 5) + b
@@ -146,35 +146,35 @@ function easing.inOutQuint(t, b, c, d)
   end
 end
 
-function easing.outInQuint(t, b, c, d)
+function Easing.outInQuint(t, b, c, d)
   if t < d / 2 then
-    return easing.outQuint(t * 2, b, c / 2, d)
+    return Easing.outQuint(t * 2, b, c / 2, d)
   else
-    return easing.inQuint((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inQuint((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inSine(t, b, c, d)
+function Easing.inSine(t, b, c, d)
   return -c * cos(t / d * (pi / 2)) + c + b
 end
 
-function easing.outSine(t, b, c, d)
+function Easing.outSine(t, b, c, d)
   return c * sin(t / d * (pi / 2)) + b
 end
 
-function easing.inOutSine(t, b, c, d)
+function Easing.inOutSine(t, b, c, d)
   return -c / 2 * (cos(pi * t / d) - 1) + b
 end
 
-function easing.outInSine(t, b, c, d)
+function Easing.outInSine(t, b, c, d)
   if t < d / 2 then
-    return easing.outSine(t * 2, b, c / 2, d)
+    return Easing.outSine(t * 2, b, c / 2, d)
   else
-    return easing.inSine((t * 2) -d, b + c / 2, c / 2, d)
+    return Easing.inSine((t * 2) -d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inExpo(t, b, c, d)
+function Easing.inExpo(t, b, c, d)
   if t == 0 then
     return b
   else
@@ -182,7 +182,7 @@ function easing.inExpo(t, b, c, d)
   end
 end
 
-function easing.outExpo(t, b, c, d)
+function Easing.outExpo(t, b, c, d)
   if t == d then
     return b + c
   else
@@ -190,7 +190,7 @@ function easing.outExpo(t, b, c, d)
   end
 end
 
-function easing.inOutExpo(t, b, c, d)
+function Easing.inOutExpo(t, b, c, d)
   if t == 0 then return b end
   if t == d then return b + c end
   t = t / d * 2
@@ -202,25 +202,25 @@ function easing.inOutExpo(t, b, c, d)
   end
 end
 
-function easing.outInExpo(t, b, c, d)
+function Easing.outInExpo(t, b, c, d)
   if t < d / 2 then
-    return easing.outExpo(t * 2, b, c / 2, d)
+    return Easing.outExpo(t * 2, b, c / 2, d)
   else
-    return easing.inExpo((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inExpo((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inCirc(t, b, c, d)
+function Easing.inCirc(t, b, c, d)
   t = t / d
   return(-c * (sqrt(1 - pow(t, 2)) - 1) + b)
 end
 
-function easing.outCirc(t, b, c, d)
+function Easing.outCirc(t, b, c, d)
   t = t / d - 1
   return(c * sqrt(1 - pow(t, 2)) + b)
 end
 
-function easing.inOutCirc(t, b, c, d)
+function Easing.inOutCirc(t, b, c, d)
   t = t / d * 2
   if t < 1 then
     return -c / 2 * (sqrt(1 - t * t) - 1) + b
@@ -230,15 +230,15 @@ function easing.inOutCirc(t, b, c, d)
   end
 end
 
-function easing.outInCirc(t, b, c, d)
+function Easing.outInCirc(t, b, c, d)
   if t < d / 2 then
-    return easing.outCirc(t * 2, b, c / 2, d)
+    return Easing.outCirc(t * 2, b, c / 2, d)
   else
-    return easing.inCirc((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inCirc((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-function easing.inElastic(t, b, c, d, a, p)
+function Easing.inElastic(t, b, c, d, a, p)
   if t == 0 then return b end
 
   t = t / d
@@ -263,7 +263,7 @@ end
 
 -- a: amplitud
 -- p: period
-function easing.outElastic(t, b, c, d, a, p)
+function Easing.outElastic(t, b, c, d, a, p)
   if t == 0 then return b end
 
   t = t / d
@@ -286,7 +286,7 @@ end
 
 -- p = period
 -- a = amplitud
-function easing.inOutElastic(t, b, c, d, a, p)
+function Easing.inOutElastic(t, b, c, d, a, p)
   if t == 0 then return b end
 
   t = t / d * 2
@@ -316,27 +316,27 @@ end
 
 -- a: amplitud
 -- p: period
-function easing.outInElastic(t, b, c, d, a, p)
+function Easing.outInElastic(t, b, c, d, a, p)
   if t < d / 2 then
-    return easing.outElastic(t * 2, b, c / 2, d, a, p)
+    return Easing.outElastic(t * 2, b, c / 2, d, a, p)
   else
-    return easing.inElastic((t * 2) - d, b + c / 2, c / 2, d, a, p)
+    return Easing.inElastic((t * 2) - d, b + c / 2, c / 2, d, a, p)
   end
 end
 
-function easing.inBack(t, b, c, d, s)
+function Easing.inBack(t, b, c, d, s)
   if not s then s = 1.70158 end
   t = t / d
   return c * t * t * ((s + 1) * t - s) + b
 end
 
-function easing.outBack(t, b, c, d, s)
+function Easing.outBack(t, b, c, d, s)
   if not s then s = 1.70158 end
   t = t / d - 1
   return c * (t * t * ((s + 1) * t + s) + 1) + b
 end
 
-function easing.inOutBack(t, b, c, d, s)
+function Easing.inOutBack(t, b, c, d, s)
   if not s then s = 1.70158 end
   s = s * 1.525
   t = t / d * 2
@@ -348,15 +348,15 @@ function easing.inOutBack(t, b, c, d, s)
   end
 end
 
-function easing.outInBack(t, b, c, d, s)
+function Easing.outInBack(t, b, c, d, s)
   if t < d / 2 then
-    return easing.outBack(t * 2, b, c / 2, d, s)
+    return Easing.outBack(t * 2, b, c / 2, d, s)
   else
-    return easing.inBack((t * 2) - d, b + c / 2, c / 2, d, s)
+    return Easing.inBack((t * 2) - d, b + c / 2, c / 2, d, s)
   end
 end
 
-function easing.outBounce(t, b, c, d)
+function Easing.outBounce(t, b, c, d)
   t = t / d
   if t < 1 / 2.75 then
     return c * (7.5625 * t * t) + b
@@ -372,24 +372,24 @@ function easing.outBounce(t, b, c, d)
   end
 end
 
-function easing.inBounce(t, b, c, d)
-  return c - easing.outBounce(d - t, 0, c, d) + b
+function Easing.inBounce(t, b, c, d)
+  return c - Easing.outBounce(d - t, 0, c, d) + b
 end
 
-function easing.inOutBounce(t, b, c, d)
+function Easing.inOutBounce(t, b, c, d)
   if t < d / 2 then
-    return easing.inBounce(t * 2, 0, c, d) * 0.5 + b
+    return Easing.inBounce(t * 2, 0, c, d) * 0.5 + b
   else
-    return easing.outBounce(t * 2 - d, 0, c, d) * 0.5 + c * .5 + b
+    return Easing.outBounce(t * 2 - d, 0, c, d) * 0.5 + c * .5 + b
   end
 end
 
-function easing.outInBounce(t, b, c, d)
+function Easing.outInBounce(t, b, c, d)
   if t < d / 2 then
-    return easing.outBounce(t * 2, b, c / 2, d)
+    return Easing.outBounce(t * 2, b, c / 2, d)
   else
-    return easing.inBounce((t * 2) - d, b + c / 2, c / 2, d)
+    return Easing.inBounce((t * 2) - d, b + c / 2, c / 2, d)
   end
 end
 
-return easing
+return Easing

--- a/src/mod/test_room/init.lua
+++ b/src/mod/test_room/init.lua
@@ -18,6 +18,7 @@ data:add_multi(
    "base.config_option",
    {
       { _id = "load_towns", type = "boolean", default = false },
+      { _id = "load_adventurers", type = "boolean", default = false },
    }
 )
 
@@ -94,7 +95,9 @@ local function on_game_start(self, player)
    Map.set_map(map)
    map:take_object(player, 25, 25)
 
-   Adventurer.initialize()
+   if config.test_room.load_adventurers then
+      Adventurer.initialize()
+   end
 
    Tools.powerup(player)
 

--- a/src/mod/tools/api/gui/LogWidget.lua
+++ b/src/mod/tools/api/gui/LogWidget.lua
@@ -67,6 +67,7 @@ end
 
 function LogWidget:draw()
    -- Draw.filled_rect(self.x, self.y, self.width, self.height, {17, 17, 65, 64})
+   Draw.set_font(12)
    local line = 1
    for i=-self.buffer:len(), -2 do
       local entry = self.buffer:get(i)

--- a/src/util/lovemock.lua
+++ b/src/util/lovemock.lua
@@ -19,6 +19,7 @@ love.graphics.getFont = function()
          getWidth = function(self, s) return #s * 8 end,
          getHeight = function() return 14 end,
          getWrap = function(text, width) return width, {text} end,
+         setFilter = function() end
       }
 end
 love.graphics.setFont = function() end
@@ -63,7 +64,12 @@ love.graphics.newCanvas = function()
 end
 love.graphics.newFont = function(path)
    check_path(path)
-   return {}
+   return {
+      getWidth = function(self, s) return #s * 8 end,
+      getHeight = function() return 14 end,
+      getWrap = function(text, width) return width, {text} end,
+      setFilter = function() end
+   }
 end
 love.graphics.newImage = function(path)
    check_path(path)
@@ -83,6 +89,7 @@ love.graphics.newShader = function()
    return {}
 end
 love.graphics.draw = function() end
+love.graphics.setDefaultFilter = function() end
 love.image.newImageData = function(path)
    check_path(path)
    return {


### PR DESCRIPTION
### Purpose of this PR
- [ ] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

### Description

Adds some new drawing APIs, and allows rendering the game screen at arbitrary positions/sizes on the "actual" window. Also allows you to register "global" draw layers that can be drawn above and below the canvas in the extra space.

Elona wasn't designed for high-DPI screens, so I thought that maybe it would be useful to be able to put some information in some fringes around the screen. I saw a video for the rerelease of a Shiren the Wanderer title that did this.

These kinds of features give me some anxiety, as they involve balancing out the fact that this is currently an experimental project to poke around at whatever ideas I have about building a living system with the fact that this might ultimately become useful to people, meaning that restraint in piling on features would eventually be required. This change was easy enough to add because the drawing system wasn't terribly complicated, but each additional feature adds even more complexity and can easily lead to a significant decline in performance. Is the utility of this feature ultimately worth the maintenance burden? It seems that only time will be able to tell.

As for why I wanted these features in the first place, the original idea was that I wanted to create a mod where Yuzuki Yukari becomes a backseat gamer and commentates on how terribly I'm playing Elona in real-time.