### PR TITLE
Implement combined diagonal keybinds

### DIFF
--- a/src/api/Gui.lua
+++ b/src/api/Gui.lua
@@ -248,6 +248,10 @@ end
 --- @tparam int tx Tile X coordinate
 --- @tparam int ty Tile Y coordinate
 function Gui.tile_to_visible_screen(tx, ty)
+   if not field.is_active or not field.renderer then
+      return nil, nil
+   end
+
   local x, y = Gui.tile_to_screen(tx, ty)
   local draw_x, draw_y = Gui.field_draw_pos()
   return x + draw_x, y + draw_y

--- a/src/api/ISoundHolder.lua
+++ b/src/api/ISoundHolder.lua
@@ -1,7 +1,7 @@
 local Draw = require("api.Draw")
-local field = require("game.field")
 local global_sound_manager = require("internal.global.global_sound_manager")
 local config = require("internal.config")
+local field = require("game.field")
 
 local ISoundHolder = class.interface("ISoundHolder", {})
 

--- a/src/api/gui/DirectionPrompt.lua
+++ b/src/api/gui/DirectionPrompt.lua
@@ -96,6 +96,8 @@ function DirectionPrompt:relayout(x, y)
       self.x, self.y = x, y
    else
       self.x, self.y = Gui.tile_to_visible_screen(self.center_x, self.center_y)
+      self.x = self.x or 0
+      self.y = self.y or 0
    end
 
    local tw, th = Draw.get_coords():get_size()
@@ -136,6 +138,10 @@ function DirectionPrompt:draw()
    draw_arrow("Southeast", x + self.tile_width, y + self.tile_height, 135)
    draw_arrow("Southwest", x + self.tile_width, y - self.tile_height, 45)
    draw_arrow("Northeast", x - self.tile_width, y + self.tile_height, 225)
+end
+
+function DirectionPrompt:set_frame(frame)
+   self.frame = frame or 0
 end
 
 function DirectionPrompt:update(dt)

--- a/src/api/gui/hud/UiDiagonalArrows.lua
+++ b/src/api/gui/hud/UiDiagonalArrows.lua
@@ -1,0 +1,52 @@
+local IUiWidget = require("api.gui.IUiWidget")
+local UiTheme = require("api.gui.UiTheme")
+local DirectionPrompt = require("api.gui.DirectionPrompt")
+local Enum = require("api.Enum")
+local Gui = require("api.Gui")
+local field = require("game.field")
+
+local UiDiagonalArrows = class.class("UiDiagonalArrows", IUiWidget)
+
+function UiDiagonalArrows:init()
+   self.directional_prompt = DirectionPrompt:new(0, 0, true)
+   self.player_x = nil
+   self.player_y = nil
+   self.y_offset = 0
+
+   self.directional_prompt:set_direction_enabled(Enum.Direction.North, false)
+   self.directional_prompt:set_direction_enabled(Enum.Direction.South, false)
+   self.directional_prompt:set_direction_enabled(Enum.Direction.East, false)
+   self.directional_prompt:set_direction_enabled(Enum.Direction.West, false)
+end
+
+function UiDiagonalArrows:default_widget_z_order()
+   return 75000
+end
+
+function UiDiagonalArrows:default_widget_refresh(player)
+   local sx, sy = Gui.tile_to_visible_screen(player.x, player.y)
+   self.player_x = sx or nil
+   self.player_y = sy or nil
+   self.y_offset = player:calc("y_offset") or 0
+end
+
+function UiDiagonalArrows:relayout(x, y)
+   self.x = x
+   self.y = y
+   self.t = UiTheme.load(self)
+end
+
+function UiDiagonalArrows:draw()
+   if self.player_x and self.player_y and Gui.is_modifier_held("alt") and field:is_querying() then
+      self.directional_prompt:relayout(self.player_x, self.player_y + self.y_offset - 16)
+      self.directional_prompt:draw()
+   else
+      self.directional_prompt:set_frame(0)
+   end
+end
+
+function UiDiagonalArrows:update(dt)
+   self.directional_prompt:update(dt)
+end
+
+return UiDiagonalArrows

--- a/src/internal/events/widget.lua
+++ b/src/internal/events/widget.lua
@@ -11,6 +11,7 @@ local UiStatsBar = require("api.gui.hud.UiStatsBar")
 local UiStatusEffects = require("api.gui.hud.UiStatusEffects")
 local UiSkillTracker = require("api.gui.hud.UiSkillTracker")
 local UiAutoTurn = require("api.gui.hud.UiAutoTurn")
+local UiDiagonalArrows = require("api.gui.hud.UiDiagonalArrows")
 
 local function add_default_widgets()
    Gui.add_hud_widget(UiMessageWindow:new(), "hud_message_window")
@@ -23,6 +24,7 @@ local function add_default_widgets()
    Gui.add_hud_widget(UiMinimap:new(), "hud_minimap")
    Gui.add_hud_widget(UiBuffs:new(), "hud_buffs")
    Gui.add_hud_widget(UiAutoTurn:new(), "hud_auto_turn")
+   Gui.add_hud_widget(UiDiagonalArrows:new(), "hud_diagonal_arrows")
 
    local position, refresh
    position = function(self, x, y, width, height)

--- a/src/internal/sound_manager.lua
+++ b/src/internal/sound_manager.lua
@@ -171,7 +171,7 @@ function sound_manager:play(id, x, y, volume, channel)
    local channel = channel or src
 
    if self.sources[channel] then
-      love.audio.stop(src)
+      love.audio.stop(self.sources[channel])
    end
 
    self.sources[channel] = src

--- a/src/mod/autoexplore/api/Autoexplore.lua
+++ b/src/mod/autoexplore/api/Autoexplore.lua
@@ -80,7 +80,7 @@ local function step_autoexplore()
       local chara = Chara.at(x, y)
       if Chara.is_alive(chara)
          and chara:relation_towards(Chara.player()) <= Enum.Relation.Enemy
-         and Effect.is_visible(chara)
+         and Effect.is_visible(chara, Chara.player())
       then
          Gui.mes("autoexplore.enemy_sighted", chara, I18N.get("autoexplore." .. pathing.type .. ".name"))
          Autoexplore.stop()

--- a/src/mod/elona/api/DeferredEvents.lua
+++ b/src/mod/elona/api/DeferredEvents.lua
@@ -459,7 +459,8 @@ function DeferredEvents.welcome_home(map)
 
    if save.elona.waiting_guests > 0 then
       local is_maid = function(chara)
-         return Servant.is_servant(chara)
+         return Chara.is_alive(chara)
+            and Servant.is_servant(chara)
             and chara:find_role("elona.maid")
       end
       local maid = Chara.iter(map):filter(is_maid):nth(1)

--- a/src/mod/elona_sys/api/Command.lua
+++ b/src/mod/elona_sys/api/Command.lua
@@ -44,7 +44,14 @@ function Command.move(player, x, y)
       x, y = Pos.add_direction(x, player.x, player.y)
    end
 
-   player.direction = Pos.pack_direction(Pos.direction_in(player.x, player.y, x, y))
+   local dx, dy = Pos.direction_in(player.x, player.y, x, y)
+
+   -- Prevent diagonal movement if Alt is held.
+   if (dx == 0 or dy == 0) and Gui.is_modifier_held("alt") then
+      return "player_turn_query"
+   end
+
+   player.direction = Pos.pack_direction(dx, dy)
 
    -- Try to modify the final position or prevent movement. This is caused by
    -- status effects like confusion, or being overweight, respectively.

--- a/src/mod/sokoban/data/map_template.lua
+++ b/src/mod/sokoban/data/map_template.lua
@@ -23,6 +23,12 @@ data:add {
       local dx = self.x - params.chara.x
       local dy = self.y - params.chara.y
 
+      if dx ~= 0 and dy ~= 0 then
+         Gui.mes_duplicate()
+         Gui.mes("sokoban.no_diagonal_movement")
+         return "turn_end"
+      end
+
       local new_x = self.x + dx
       local new_y = self.y + dy
 

--- a/src/mod/test_room/init.lua
+++ b/src/mod/test_room/init.lua
@@ -100,6 +100,15 @@ local function on_game_start(self, player)
    end
 
    Tools.powerup(player)
+   player:mod_base_skill_level("elona.stat_dexterity", 100, "set")
+   player:mod_base_skill_level("elona.marksman", 100, "set")
+   player:mod_base_skill_level("elona.bow", 100, "set")
+   player:mod_base_skill_level("elona.spell_crystal_spear", 50, "set")
+   player:mod_base_skill_level("elona.spell_magic_storm", 50, "set")
+   player:mod_base_skill_level("elona.stat_mana", 250, "set")
+   player:mod_base_skill_level("elona.lock_picking", 250, "set")
+   player:refresh()
+   player:heal_to_max()
 
    player.gold = 10^8
    player.platinum = 1000

--- a/src/mod/test_room/init.lua
+++ b/src/mod/test_room/init.lua
@@ -100,15 +100,6 @@ local function on_game_start(self, player)
    end
 
    Tools.powerup(player)
-   player:mod_base_skill_level("elona.stat_dexterity", 100, "set")
-   player:mod_base_skill_level("elona.marksman", 100, "set")
-   player:mod_base_skill_level("elona.bow", 100, "set")
-   player:mod_base_skill_level("elona.spell_crystal_spear", 50, "set")
-   player:mod_base_skill_level("elona.spell_magic_storm", 50, "set")
-   player:mod_base_skill_level("elona.stat_mana", 250, "set")
-   player:mod_base_skill_level("elona.lock_picking", 250, "set")
-   player:refresh()
-   player:heal_to_max()
 
    player.gold = 10^8
    player.platinum = 1000


### PR DESCRIPTION
### Purpose of this PR
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature

### Related issues

<!--
Include related issues, if any, or omit. Example:

#2, #8. Closes #12.
-->

Closes #292.

### Description

Implements diagonal movement keybinds triggerable by holding down more than one movement key.